### PR TITLE
feat: ONTAP MCP server Docker file should support config passing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ COPY --from=builder $INSTALL_DIR $INSTALL_DIR
 
 WORKDIR $INSTALL_DIR
 
-ENTRYPOINT ["./ontap-mcp", "start", "--config", "server/testdata/ontap.yaml"]
+ENTRYPOINT ["./ontap-mcp"]
+CMD ["start"]
+

--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/alecthomas/kong"
 	"github.com/netapp/ontap-mcp/config"
 	"github.com/netapp/ontap-mcp/server"
@@ -14,7 +15,7 @@ var logger = setupLogger()
 
 type Globals struct {
 	LogLevel   string `enum:"debug,info,warn,error" default:"info" env:"LOG_LEVEL" help:"Log level, one of: ${enum}"`
-	ConfigPath string `name:"config" default:"ontap.yaml" env:"CONFIG" help:"ONTAP-MCP config path"`
+	ConfigPath string `name:"config" default:"ontap.yaml" env:"ONTAP_MCP_CONFIG" help:"ONTAP-MCP config path"`
 }
 
 type CLI struct {
@@ -30,9 +31,14 @@ type StartCmd struct {
 }
 
 func (a *StartCmd) Run(cli *CLI) error {
+	abs, err := filepath.Abs(cli.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to Abs config path=%s err=%w", cli.ConfigPath, err)
+	}
+	logger.Info("Reading config", slog.String("path", abs))
 	cfg, err := config.ReadConfig(cli.ConfigPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read config path=%s err=%w", cli.ConfigPath, err)
 	}
 
 	opts := server.Options{


### PR DESCRIPTION
Example: `docker run --rm -v $(pwd)/ontap.yaml:/opt/mcp/ontap.yaml ontap-mcp:local`