### PR TITLE
refactor: error from ontap_get retry as debug

### DIFF
--- a/integration/test/tools_test.go
+++ b/integration/test/tools_test.go
@@ -208,13 +208,13 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 			result, err := a.callMCPTool(ctx, toolName, args)
 			if err != nil {
 				if expectedOntapErrorStr != "" && strings.Contains(err.Error(), expectedOntapErrorStr) {
-					slog.Debug("Expected tool error", slog.String("tool", toolName), slog.Any("error", err))
-				} else {
-					failedTool = toolName
-					argsUsed = args
-					errFound = err
-					slog.Warn("LLM will retry", slog.String("tool", toolName), slog.Any("args", args), slog.Any("error", err))
+					return "", nil // test passed, expected error was observed
 				}
+				failedTool = toolName
+				argsUsed = args
+				errFound = err
+				slog.Warn("LLM will retry", slog.String("tool", toolName), slog.Any("args", args), slog.Any("error", err))
+
 				result = "Error: " + err.Error()
 			}
 
@@ -224,7 +224,7 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 	}
 
 	t.Errorf("Tool %q args %v returned error %v", failedTool, argsUsed, errFound)
-	return "", fmt.Errorf("max iterations (%d) reached without final assistant message", maxIterations)
+	return "", fmt.Errorf("max iterations (%d) reached; last tool %q args %v error: %w", maxIterations, failedTool, argsUsed, errFound)
 }
 
 func (a *Agent) Close() {

--- a/integration/test/tools_test.go
+++ b/integration/test/tools_test.go
@@ -172,6 +172,10 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 	tools := a.convertMCPToolsToOpenAI()
 	maxIterations := 10
 
+	var errFound error
+	failedTool := ""
+	argsUsed := make(map[string]any)
+
 	for range maxIterations {
 		completion, err := a.openaiClient.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
 			Model:    a.model,
@@ -203,23 +207,23 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 
 			result, err := a.callMCPTool(ctx, toolName, args)
 			if err != nil {
-				switch {
-				case expectedOntapErrorStr != "" && strings.Contains(err.Error(), expectedOntapErrorStr):
+				if expectedOntapErrorStr != "" && strings.Contains(err.Error(), expectedOntapErrorStr) {
 					slog.Debug("Expected tool error", slog.String("tool", toolName), slog.Any("error", err))
-				case toolName == "ontap_get" && strings.Contains(err.Error(), "invalid for field"):
-					slog.Debug("LLM would retry", slog.String("tool", toolName), slog.Any("args", args), slog.Any("error", err))
-				default:
-					t.Errorf("Tool %q args %v returned error LLM will retry: %v", toolName, args, err)
+				} else {
+					failedTool = toolName
+					argsUsed = args
+					errFound = err
+					slog.Warn("LLM will retry", slog.String("tool", toolName), slog.Any("args", args), slog.Any("error", err))
 				}
 				result = "Error: " + err.Error()
 			}
 
 			slog.Debug("", slog.Any("Tool result", result))
-
 			messages = append(messages, openai.ToolMessage(result, toolCall.ID))
 		}
 	}
 
+	t.Errorf("Tool %q args %v returned error %v", failedTool, argsUsed, errFound)
 	return "", fmt.Errorf("max iterations (%d) reached without final assistant message", maxIterations)
 }
 

--- a/integration/test/tools_test.go
+++ b/integration/test/tools_test.go
@@ -185,7 +185,6 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 		}
 
 		assistantMessage := completion.Choices[0].Message
-
 		if len(assistantMessage.ToolCalls) == 0 {
 			return assistantMessage.Content, nil
 		}
@@ -204,10 +203,13 @@ func (a *Agent) ChatWithResponse(ctx context.Context, t *testing.T, userMessage 
 
 			result, err := a.callMCPTool(ctx, toolName, args)
 			if err != nil {
-				if expectedOntapErrorStr != "" && strings.Contains(err.Error(), expectedOntapErrorStr) {
+				switch {
+				case expectedOntapErrorStr != "" && strings.Contains(err.Error(), expectedOntapErrorStr):
 					slog.Debug("Expected tool error", slog.String("tool", toolName), slog.Any("error", err))
-				} else {
-					t.Errorf("Tool %q returned error LLM will retry: %v", toolName, err)
+				case toolName == "ontap_get" && strings.Contains(err.Error(), "invalid for field"):
+					slog.Debug("LLM would retry", slog.String("tool", toolName), slog.Any("args", args), slog.Any("error", err))
+				default:
+					t.Errorf("Tool %q args %v returned error LLM will retry: %v", toolName, args, err)
 				}
 				result = "Error: " + err.Error()
 			}


### PR DESCRIPTION
Validated with sample input prompt as `show all luns in marketing svm in umeng-aff300-05-06  cluster`.

Our LLM always do retry in case of error, but it's logged as error where it's already correcting itself in `ontap_get` case.
Refactor this case in switch and made it debug.

```
=== RUN   TestLuns/Show_luns
2026/04/10 14:34:02 INFO LLM would retry tool=ontap_get args="map[cluster_name:umeng-aff300-05-06 fields:name,size,uuid,state,volume.name,svm.name filters:map[svm.name:marketing] path:/storage/luns]" error="error running the tool: ErrValidator: message: The value \"size\" is invalid for field \"fields\" (<field,...>) code: 262197"
2026/04/10 14:34:05 INFO LLM would retry tool=ontap_get args="map[cluster_name:umeng-aff300-05-06 fields:name,uuid,state,volume.name,svm.name filters:map[svm.name:marketing] path:/storage/luns]" error="error running the tool: ErrValidator: message: The value \"state\" is invalid for field \"fields\" (<field,...>) code: 262197"
2026/04/10 14:34:09 INFO LLM would retry tool=ontap_get args="map[cluster_name:umeng-aff300-05-06 fields:name,uuid,volume.name,svm.name filters:map[svm.name:marketing] path:/storage/luns]" error="error running the tool: ErrValidator: message: The value \"volume.name\" is invalid for field \"fields\" (<field,...>) code: 262197"
--- PASS: TestLuns (19.13s)
--- PASS: TestLuns/Show_luns (19.13s)
```