### PR TITLE
feat: add --json-response CLI flag

### DIFF
--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -31,7 +31,7 @@ type StartCmd struct {
 	InspectTraffic bool   `default:"false" help:"Inspect MCP HTTP traffic"`
 	ReadOnly       bool   `default:"false" help:"Run MCP in read-only mode. This disables all tool calls that modify ONTAP state."`
 	Stateless      bool   `default:"false" help:"Run in stateless mode (no mcp-session-id header validation). Required when deploying behind proxies or gateways that don't preserve session headers, e.g. on-premises data gateways."`
-	JSONResponse   bool   `default:"false" help:"Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. Power Platform on-premises data gateway."`
+	JSONResponse   bool   `default:"false" help:"Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. on-premises data gateways."`
 }
 
 func (a *StartCmd) Run(cli *CLI) error {

--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -31,6 +31,7 @@ type StartCmd struct {
 	InspectTraffic bool   `default:"false" help:"Inspect MCP HTTP traffic"`
 	ReadOnly       bool   `default:"false" help:"Run MCP in read-only mode. This disables all tool calls that modify ONTAP state."`
 	Stateless      bool   `default:"false" help:"Run in stateless mode (no mcp-session-id header validation). Required when deploying behind proxies or gateways that don't preserve session headers, e.g. on-premises data gateways."`
+	JSONResponse   bool   `default:"false" help:"Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. Power Platform on-premises data gateway."`
 }
 
 func (a *StartCmd) Run(cli *CLI) error {
@@ -50,6 +51,7 @@ func (a *StartCmd) Run(cli *CLI) error {
 		InspectTraffic: cli.Start.InspectTraffic,
 		ReadOnly:       cli.Start.ReadOnly,
 		Stateless:      cli.Start.Stateless,
+		JSONResponse:   cli.Start.JSONResponse,
 	}
 
 	app := server.NewApp(cfg, opts, logger)

--- a/docs/install.md
+++ b/docs/install.md
@@ -135,6 +135,7 @@ Some commonly used flags:
 |---|---|
 | `--read-only` | Disable all mutating operations. Only read-only tools are registered. |
 | `--stateless` | Disable mcp-session-id header validation. Required when deploying behind proxies or gateways that do not preserve session headers, e.g. on-premises data gateways. |
+| `--json-response` | Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. Power Platform on-premises data gateway. |
 | `--inspect-traffic` | Log all MCP HTTP request and response bodies for debugging. |
 
 ## Next Steps

--- a/docs/install.md
+++ b/docs/install.md
@@ -135,7 +135,7 @@ Some commonly used flags:
 |---|---|
 | `--read-only` | Disable all mutating operations. Only read-only tools are registered. |
 | `--stateless` | Disable mcp-session-id header validation. Required when deploying behind proxies or gateways that do not preserve session headers, e.g. on-premises data gateways. |
-| `--json-response` | Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. Power Platform on-premises data gateway. |
+| `--json-response` | Respond with application/json instead of text/event-stream. Required when deploying behind proxies or gateways that do not relay SSE/chunked responses, e.g. on-premises data gateways. |
 | `--inspect-traffic` | Log all MCP HTTP request and response bodies for debugging. |
 
 ## Next Steps

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -10,6 +10,8 @@ If you want to run the ONTAP MCP server in read-only mode, you can start the ser
 
 To run without mcp-session-id header validation (e.g. behind proxies that strip session headers), use the `--stateless` flag. See the [configuration documentation](install.md#configuration) for more details.
 
+To respond with `application/json` instead of `text/event-stream` (e.g. behind gateways that do not relay SSE/chunked responses), use the `--json-response` flag. See the [configuration documentation](install.md#configuration) for more details.
+
 ## API Discovery
 
 - `list_ontap_endpoints` (available when the API catalog is loaded)

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ type Options struct {
 	Port           int
 	ReadOnly       bool
 	Stateless      bool
+	JSONResponse   bool
 	TestHTTPClient *http.Client // Optional HTTP client for testing
 }
 
@@ -81,6 +82,9 @@ func (a *App) StartServer() {
 	}
 	if a.options.Stateless {
 		a.logger.Info("MCP server is running in stateless mode; mcp-session-id header validation is disabled")
+	}
+	if a.options.JSONResponse {
+		a.logger.Info("MCP server is responding with application/json instead of text/event-stream")
 	}
 	server := a.createMCPServer()
 	a.runHTTPServer(server)
@@ -243,7 +247,7 @@ func (a *App) runHTTPServer(server *mcp.Server) {
 
 	handler = mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return server
-	}, &mcp.StreamableHTTPOptions{Stateless: a.options.Stateless})
+	}, &mcp.StreamableHTTPOptions{Stateless: a.options.Stateless, JSONResponse: a.options.JSONResponse})
 
 	if a.options.InspectTraffic {
 		prevHandler := handler


### PR DESCRIPTION
Wires the existing `StreamableHTTPOptions.JSONResponse` SDK field to a CLI flag so the server returns `application/json` instead of `text/event-stream`. Required for deployments behind proxies that cannot relay SSE/chunked responses (e.g. Power Platform on-premises data gateway).

In context of discussion #126.

**Changes:**
- Add `--json-response` flag to `StartCmd` and wire to `server.Options`
- Pass `JSONResponse` to `mcp.StreamableHTTPOptions` in the HTTP handler
- Log when json-response mode is active
- Update `docs/install.md` flags table and `docs/tools.md` with usage guidance

Closes #128