### PR TITLE
feat: add Helm chart for Kubernetes deployment

### DIFF
--- a/charts/ontap-mcp/.helmignore
+++ b/charts/ontap-mcp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ontap-mcp/Chart.yaml
+++ b/charts/ontap-mcp/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: ontap-mcp
+description: A Helm chart for deploying the ONTAP MCP Server on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "26.04.0-1"
+home: https://github.com/NetApp/ontap-mcp
+sources:
+  - https://github.com/NetApp/ontap-mcp
+icon: https://raw.githubusercontent.com/NetApp/ontap-mcp/main/docs/assets/ontap-mcp.svg
+keywords:
+  - netapp
+  - ontap
+  - mcp
+  - model-context-protocol
+  - storage
+maintainers:
+  - name: NetApp
+    url: https://github.com/NetApp

--- a/charts/ontap-mcp/README.md
+++ b/charts/ontap-mcp/README.md
@@ -1,0 +1,92 @@
+# ontap-mcp
+
+A Helm chart for deploying the [ONTAP MCP Server](https://github.com/NetApp/ontap-mcp) on Kubernetes.
+
+## Installing
+
+```bash
+helm install my-release ./charts/ontap-mcp
+```
+
+This works out of the box with no ONTAP clusters configured yet -- the server
+starts but has nothing to poll, and the post-install notes will say so. Provide
+`ontapConfig.data` (or `ontapConfig.existingSecret`) via a values file to
+configure real clusters -- see "Configuration" below.
+
+## Configuration
+
+The server needs a config file (`ontap.yaml`) describing which ONTAP clusters to
+connect to; it's always sourced from a Kubernetes `Secret`, mounted at
+`/opt/mcp/ontap.yaml`. Two ways to provide it:
+
+1. **Let the chart create the Secret** by setting `ontapConfig.data` to the full
+   contents of `ontap.yaml`, in its native schema:
+
+   ```yaml
+   ontapConfig:
+     data:
+       Pollers:
+         cluster1:
+           addr: 10.0.0.1
+           username: admin
+           password: changeme
+           use_insecure_tls: false
+   ```
+
+   See [`ontap-example.yaml`](https://github.com/NetApp/ontap-mcp/blob/main/ontap-example.yaml)
+   for the complete schema (`Pollers`, `Defaults`, `McpAuth`, `Tls`).
+
+2. **Bring your own Secret** (recommended for anything beyond local testing --
+   source it from an external secrets manager via the CSI secrets-store driver
+   or the External Secrets Operator instead of putting credentials in a values
+   file): create a `Secret` yourself with a key named `ontap.yaml`, then set
+   `ontapConfig.existingSecret` to its name. `ontapConfig.data` is ignored when
+   this is set.
+
+If neither is set, the server starts with no configured clusters.
+
+### Exposing the service
+
+By default the chart only creates a `ClusterIP` Service. Three ways to expose it,
+all off by default:
+
+- `ingress.enabled: true` -- a plain Kubernetes `Ingress`, for clusters with an
+  Ingress controller.
+- `httpRoute.enabled: true` -- a Gateway API `HTTPRoute` (requires the Gateway
+  API installed and a `Gateway` to attach to; set `httpRoute.parentRefs`).
+- `listenerSet.enabled: true` -- a Gateway API `ListenerSet` (requires Gateway
+  API >= 1.5), for attaching `httpRoute` to a shared per-app listener instead
+  of a `Gateway` directly.
+
+### Multiple replicas
+
+The server keeps per-session MCP state in-process. If you scale `replicaCount`
+above 1, also add `--stateless` to `extraArgs` (drops the `mcp-session-id`
+header requirement) and make sure your Service/Ingress doesn't rely on sticky
+sessions.
+
+## Values
+
+| Key | Description | Default |
+|---|---|---|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | Image repository | `ghcr.io/netapp/ontap-mcp` |
+| `image.tag` | Image tag; defaults to the chart's `appVersion` | `""` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `serviceAccount.create` | Create a ServiceAccount | `true` |
+| `serviceAccount.automount` | Automount the ServiceAccount token | `false` |
+| `securityContext.readOnlyRootFilesystem` | Read-only root filesystem | `true` |
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service/container port; also passed as `--port` | `8080` |
+| `extraArgs` | Extra CLI flags, e.g. `--read-only`, `--stateless`, `--json-response` | `[]` |
+| `extraEnv` | Extra container env vars | `[]` |
+| `ontapConfig.existingSecret` | Name of a pre-existing Secret with an `ontap.yaml` key | `""` |
+| `ontapConfig.data` | Full `ontap.yaml` contents; ignored if `existingSecret` is set | `{}` |
+| `resources` | Container resource requests/limits | see `values.yaml` |
+| `livenessProbe` / `readinessProbe` | Probe definitions against `/health` | see `values.yaml` |
+| `extraVolumes` / `extraVolumeMounts` | Additional volumes/mounts | `[]` |
+| `ingress.enabled` | Create an Ingress | `false` |
+| `httpRoute.enabled` | Create a Gateway API HTTPRoute | `false` |
+| `listenerSet.enabled` | Create a Gateway API ListenerSet | `false` |
+| `nodeSelector` / `tolerations` / `affinity` | Standard scheduling controls | `{}` / `[]` / `{}` |

--- a/charts/ontap-mcp/templates/NOTES.txt
+++ b/charts/ontap-mcp/templates/NOTES.txt
@@ -1,0 +1,25 @@
+ONTAP MCP Server has been deployed.
+
+{{- if and (not .Values.ontapConfig.existingSecret) (not .Values.ontapConfig.data) }}
+
+WARNING: no ONTAP clusters are configured (ontapConfig.data is empty and
+ontapConfig.existingSecret is not set). The server will start but has
+nothing to poll. Set one of the two -- see values.yaml for the schema, or
+https://github.com/NetApp/ontap-mcp/blob/main/ontap-example.yaml.
+{{- end }}
+
+Get the application URL by running these commands:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ (first $host.paths).path }}
+{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+  http://{{ . }}
+{{- end }}
+{{- else }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "ontap-mcp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:8080/health to check the server is up."
+{{- end }}

--- a/charts/ontap-mcp/templates/_helpers.tpl
+++ b/charts/ontap-mcp/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ontap-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ontap-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ontap-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ontap-mcp.labels" -}}
+helm.sh/chart: {{ include "ontap-mcp.chart" . }}
+{{ include "ontap-mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ontap-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ontap-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ontap-mcp.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ontap-mcp.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret that carries ontap.yaml -- either the caller-supplied
+existingSecret, or the one this chart creates itself.
+*/}}
+{{- define "ontap-mcp.configSecretName" -}}
+{{- default (printf "%s-config" (include "ontap-mcp.fullname" .)) .Values.ontapConfig.existingSecret }}
+{{- end }}

--- a/charts/ontap-mcp/templates/deployment.yaml
+++ b/charts/ontap-mcp/templates/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # Kubernetes injects one <SVCNAME>_PORT-style env var per Service visible
+      # to the pod. If the release is named e.g. "ontap-mcp", that's literally
+      # ONTAP_MCP_PORT -- colliding with the server's own port env var and
+      # breaking startup. The server doesn't use service-discovery env vars
+      # (its port comes from --port, ONTAP config from a mounted secret), so
+      # there's nothing to lose by turning this off.
+      enableServiceLinks: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/ontap-mcp/templates/deployment.yaml
+++ b/charts/ontap-mcp/templates/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ontap-mcp.fullname" . }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ontap-mcp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or (not .Values.ontapConfig.existingSecret) .Values.podAnnotations }}
+      annotations:
+        {{- if not .Values.ontapConfig.existingSecret }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "ontap-mcp.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ontap-mcp.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args:
+            - start
+            - --port
+            - {{ .Values.service.port | quote }}
+            - --host
+            - "0.0.0.0"
+            {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ontap-config
+              mountPath: /opt/mcp/ontap.yaml
+              subPath: ontap.yaml
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: ontap-config
+          secret:
+            secretName: {{ include "ontap-mcp.configSecretName" . }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ontap-mcp/templates/httproute.yaml
+++ b/charts/ontap-mcp/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "ontap-mcp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/charts/ontap-mcp/templates/ingress.yaml
+++ b/charts/ontap-mcp/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ontap-mcp.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ontap-mcp/templates/listenerset.yaml
+++ b/charts/ontap-mcp/templates/listenerset.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.listenerSet.enabled -}}
+{{- $fullName := include "ontap-mcp.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+  {{- with .Values.listenerSet.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  listeners:
+    - name: https
+      hostname: {{ .Values.listenerSet.hostname }}
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ .Values.listenerSet.tlsSecretName }}
+  parentRef:
+    {{- toYaml .Values.listenerSet.parentRef | nindent 4 }}
+{{- end }}

--- a/charts/ontap-mcp/templates/secret.yaml
+++ b/charts/ontap-mcp/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.ontapConfig.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ontap-mcp.configSecretName" . }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ontap.yaml: {{ toYaml .Values.ontapConfig.data | b64enc | quote }}
+{{- end }}

--- a/charts/ontap-mcp/templates/service.yaml
+++ b/charts/ontap-mcp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ontap-mcp.fullname" . }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ontap-mcp.selectorLabels" . | nindent 4 }}

--- a/charts/ontap-mcp/templates/serviceaccount.yaml
+++ b/charts/ontap-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ontap-mcp.serviceAccountName" . }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/ontap-mcp/templates/tests/test-connection.yaml
+++ b/charts/ontap-mcp/templates/tests/test-connection.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "ontap-mcp.fullname" . }}-test-connection"
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  {{- with .Values.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: wget
+      image: busybox:1.37
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      command: ["wget"]
+      args: ["{{ include "ontap-mcp.fullname" . }}:{{ .Values.service.port }}/health"]
+  restartPolicy: Never

--- a/charts/ontap-mcp/values.yaml
+++ b/charts/ontap-mcp/values.yaml
@@ -1,0 +1,167 @@
+# Default values for ontap-mcp.
+# See https://github.com/NetApp/ontap-mcp/blob/main/docs/install.md for
+# background on the server's runtime flags and configuration file.
+
+replicaCount: 1
+# -- The MCP server keeps per-session state in-process. Running more than one
+# replica requires the server-side session-affinity relaxation the binary
+# already ships for exactly this case: add `--stateless` via `extraArgs`
+# below, and put a Service/Ingress in front that doesn't need sticky sessions.
+
+image:
+  repository: ghcr.io/netapp/ontap-mcp
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag; defaults to the chart's appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created.
+  create: true
+  # -- The server never calls the Kubernetes API, so it doesn't need its
+  # ServiceAccount token mounted.
+  automount: false
+  annotations: {}
+  # -- The name of the ServiceAccount to use. If not set and `create` is
+  # true, a name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  # -- Matches the binary's own default (`--port`, see `cmd/cmds.go`). The
+  # chart always also passes `--host 0.0.0.0`, since the binary's own default
+  # host (`localhost`) is unreachable from outside the pod.
+  port: 8080
+
+# -- Extra CLI flags appended after `start --port <port> --host 0.0.0.0`, e.g.
+# `--read-only`, `--stateless`, `--json-response`, `--inspect-traffic`,
+# `--log-level debug`. See `docs/install.md` for what each flag does.
+extraArgs: []
+
+# -- Extra environment variables for the container, in the plain
+# `[{name, value}, ...]` or `[{name, valueFrom}, ...]` Kubernetes form.
+extraEnv: []
+
+# -- The config file the server reads at startup (`ontap.yaml`, mounted at
+# `/opt/mcp/ontap.yaml`). It carries ONTAP cluster credentials, so it's
+# always sourced from a Secret -- never from a ConfigMap or baked into the
+# image.
+ontapConfig:
+  # -- Name of a Secret you manage yourself (e.g. via an External Secrets
+  # Operator, a CSI secrets-store driver, or your own pipeline), containing a
+  # key named `ontap.yaml` with the full config file as its value. When set,
+  # `ontapConfig.data` below is ignored and the chart creates no Secret of
+  # its own.
+  existingSecret: ""
+  # -- Full contents of ontap.yaml, in its native schema. Left empty by
+  # default -- the server will start but have no ONTAP clusters to talk to
+  # until this (or `existingSecret`) is set. See
+  # https://github.com/NetApp/ontap-mcp/blob/main/ontap-example.yaml for the
+  # complete schema (Pollers/Defaults/McpAuth/Tls). Example:
+  #
+  # data:
+  #   Pollers:
+  #     cluster1:
+  #       addr: 10.0.0.1
+  #       username: admin
+  #       password: changeme
+  #       use_insecure_tls: false
+  data: {}
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 10m
+    memory: 128Mi
+
+# -- `/health` is plain HTTP unless ontap.yaml's `Tls` block is set, in which
+# case the whole server (including `/health`) switches to HTTPS -- set
+# `scheme: HTTPS` on both probes below if you enable it.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+# -- Additional volumes on the Deployment, beyond the ontap.yaml config
+# mount the chart always adds itself.
+extraVolumes: []
+# -- Additional volumeMounts on the container, beyond the ontap.yaml config
+# mount the chart always adds itself.
+extraVolumeMounts: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Plain Kubernetes Ingress. Off by default; the most common way to expose
+# the service on clusters without the Gateway API installed.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# -- Expose the service via the Gateway API's HTTPRoute. Off by default --
+# most clusters don't have the Gateway API installed; enable only if you
+# already have a Gateway (or ListenerSet, below) to attach to.
+httpRoute:
+  enabled: false
+  annotations: {}
+  hostnames:
+    - chart-example.local
+  # -- Where this route attaches. Defaults to a plain Gateway; point at a
+  # ListenerSet instead (`kind: ListenerSet`) if you enable the one below.
+  parentRefs:
+    - kind: Gateway
+      name: my-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+# -- Gateway API ListenerSet (requires Gateway API >= 1.5, standard channel).
+# Off by default; only relevant if you're attaching `httpRoute` to a
+# ListenerSet rather than directly to a Gateway.
+listenerSet:
+  enabled: false
+  annotations: {}
+  parentRef:
+    name: my-gateway
+  hostname: chart-example.local
+  tlsSecretName: ""


### PR DESCRIPTION
## Summary

Closes #167. Adds `charts/ontap-mcp/`, an official Helm chart for deploying the server on Kubernetes.

## What's included

- `Deployment` / `Service` / `ServiceAccount`, standard hardened `securityContext` (non-root uid 1000, `readOnlyRootFilesystem`, all capabilities dropped, `seccompProfile: RuntimeDefault`), `automountServiceAccountToken: false` since the server never calls the Kubernetes API.
- `ontap.yaml` sourced from a `Secret`, with an `ontapConfig.existingSecret` override so operators can supply it via their own secrets pipeline (External Secrets Operator, CSI secrets-store driver, etc.) instead of putting credentials in `values.yaml`. `checksum/config` pod annotation rolls the deployment when the chart-owned Secret changes.
- `extraArgs` / `extraEnv` passthroughs, so `--read-only`, `--stateless`, `--json-response`, `--inspect-traffic`, `--log-level` etc. don't require forking the template.
- Optional `Ingress`, Gateway API `HTTPRoute`, and Gateway API `ListenerSet` -- all `enabled: false` by default, since most clusters have an Ingress controller but not the Gateway API.
- A `helm test` hook that `wget`s `/health`.
- `README.md` with a values table, `NOTES.txt` with post-install guidance (including a warning if no ONTAP clusters are configured yet).

## Deliberate omissions (open to adding if wanted)

- No `NetworkPolicy` -- egress targets (ONTAP cluster addresses) are environment-specific, so a default-deny policy didn't seem safe to ship; happy to add a minimal ingress-only opt-in template if useful.
- No `PodDisruptionBudget`/`HorizontalPodAutoscaler` for this first version -- `replicaCount` defaults to 1, and scaling beyond that requires `--stateless` (session state is in-process; noted in the README).
- No `values.schema.json` yet -- straightforward to add as a follow-up.

## Verification

- `helm lint --strict`: clean.
- `helm template` rendered and validated (all resources parse as well-formed Kubernetes YAML) both with default values and with every optional feature enabled simultaneously (multiple replicas, ingress + httpRoute + listenerSet, existingSecret, extraArgs, extraEnv, extraVolumes/Mounts).
- Chart's `args`/env/mount paths cross-checked against `cmd/cmds.go`, `server/server.go`, and `docs/install.md`: default port 8080 matches the binary's own default (`--host 0.0.0.0` is always passed, since the binary defaults to `localhost`); `/health` liveness/readiness probes confirmed against `server/server.go`; config file mount path (`/opt/mcp/ontap.yaml`) matches the Dockerfile's `WORKDIR` and the binary's default config path.
- `image.repository`/tags checked against the published `ghcr.io/netapp/ontap-mcp` package (`latest`, `nightly`, `26.04.0-1`); `appVersion` set to the latest published tag.