### PR TITLE
feat: add initiators field to create_igroup for atomic create-with-membership

### DIFF
--- a/integration/test/igroup_test.go
+++ b/integration/test/igroup_test.go
@@ -76,10 +76,16 @@ func TestIGroupLUNMap(t *testing.T) {
 			verifyAPI:        ontapVerifier{api: "api/storage/luns?name=/vol/" + rn("doc") + "/" + rn("lundoc") + "&svm.name=" + rn("marketing"), validationFunc: deleteObject},
 		},
 		{
-			name:             "Create igroup",
-			input:            ClusterStr + "create an igroup named " + rn("igroupFin") + " with OS type linux and protocol iscsi on the " + rn("marketing") + " svm",
+			name:             "Create igroup with initiators atomically",
+			input:            ClusterStr + "create an igroup named " + rn("igroupFin") + " with OS type linux and protocol iscsi on the " + rn("marketing") + " svm with initiator iqn.2021-01.com.example:test",
 			expectedOntapErr: "",
-			verifyAPI:        ontapVerifier{api: "api/protocols/san/igroups?name=" + rn("igroupFin") + "&svm.name=" + rn("marketing"), validationFunc: createObject},
+			verifyAPI:        ontapVerifier{api: "api/protocols/san/igroups?name=" + rn("igroupFin") + "&svm.name=" + rn("marketing") + "&fields=initiators", validationFunc: verifyInitiator(true, "iqn.2021-01.com.example:test")},
+		},
+		{
+			name:             "Remove initiator from igroup",
+			input:            ClusterStr + "remove initiator iqn.2021-01.com.example:test from igroup " + rn("igroupFin") + " on the " + rn("marketing") + " svm",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{api: "api/protocols/san/igroups?name=" + rn("igroupFin") + "&svm.name=" + rn("marketing") + "&fields=initiators", validationFunc: verifyInitiator(false, "iqn.2021-01.com.example:test")},
 		},
 		{
 			name:             "Add initiator to igroup",

--- a/ontap/ontap.go
+++ b/ontap/ontap.go
@@ -373,11 +373,12 @@ type IGroupInitiator struct {
 }
 
 type IGroup struct {
-	SVM      NameAndUUID `json:"svm,omitzero"`
-	Name     string      `json:"name,omitzero"`
-	OSType   string      `json:"os_type,omitzero"`
-	Protocol string      `json:"protocol,omitzero"`
-	Comment  string      `json:"comment,omitzero"`
+	SVM        NameAndUUID     `json:"svm,omitzero"`
+	Name       string          `json:"name,omitzero"`
+	OSType     string          `json:"os_type,omitzero"`
+	Protocol   string          `json:"protocol,omitzero"`
+	Comment    string          `json:"comment,omitzero"`
+	Initiators []InitiatorName `json:"initiators,omitzero"`
 }
 
 type LunMap struct {

--- a/rest/cifsService.go
+++ b/rest/cifsService.go
@@ -23,7 +23,7 @@ func (c *Client) CreateCIFSService(ctx context.Context, cifsService ontap.CIFSSe
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsService ontap.CIFSServiceBody) error {
@@ -47,7 +47,7 @@ func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsServ
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassword string) error {
@@ -88,5 +88,5 @@ func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassw
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/client.go
+++ b/rest/client.go
@@ -26,11 +26,12 @@ import (
 )
 
 type Client struct {
-	poller     *config.Poller
-	httpClient *http.Client
-	credCache  credentialsCache
-	remote     ontap.Remote
-	initOnce   sync.Once
+	poller          *config.Poller
+	httpClient      *http.Client
+	credCache       credentialsCache
+	remote          ontap.Remote
+	initOnce        sync.Once
+	jobPollInterval time.Duration
 }
 
 // credentials holds authentication information
@@ -41,28 +42,32 @@ type credentials struct {
 }
 
 func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
-	if statusCode == http.StatusCreated || statusCode == http.StatusAccepted {
-		var pj ontap.PostJob
-		err := json.Unmarshal(buf.Bytes(), &pj)
-		if err != nil {
-			return err
-		}
-
-		err = c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
-		if err != nil {
-			return err
-		}
+	if err := c.checkStatus(statusCode); err != nil {
+		return err
+	}
+	if statusCode != http.StatusAccepted {
+		return nil
 	}
 
-	return nil
+	var pj ontap.PostJob
+	if err := json.Unmarshal(buf.Bytes(), &pj); err != nil {
+		return fmt.Errorf("failed to decode async job response: %w", err)
+	}
+	if strings.TrimSpace(pj.Job.UUID) == "" {
+		return fmt.Errorf("async job response is missing job UUID")
+	}
+
+	return c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
 }
 
 //nolint:unparam
 func (c *Client) waitForJob(ctx context.Context, jobLocation string, duration time.Duration) error {
 	var jr ontap.JobResponse
 
-	// Poll every pollInterval seconds, up to duration
-	const pollInterval = 2 * time.Second
+	pollInterval := c.jobPollInterval
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
 	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -41,7 +41,7 @@ type credentials struct {
 	AuthToken string
 }
 
-func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
+func (c *Client) handleJob(ctx context.Context, statusCode int, buf *bytes.Buffer) error {
 	if err := c.checkStatus(statusCode); err != nil {
 		return err
 	}

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -26,7 +26,7 @@ func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -13,17 +14,19 @@ import (
 func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/igroups`, &statusCode, responseHeaders).
-		BodyJSON(igroup)
+		BodyJSON(igroup).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -12,17 +13,19 @@ import (
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/luns`, &statusCode, responseHeaders).
-		BodyJSON(lun)
+		BodyJSON(lun).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
@@ -25,7 +26,7 @@ func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -10,17 +11,21 @@ import (
 )
 
 func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
-	var statusCode int
+	var (
+		statusCode int
+		buf        bytes.Buffer
+	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/lun-maps`, &statusCode, responseHeaders).
-		BodyJSON(lunMap)
+		BodyJSON(lunMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -25,7 +25,7 @@ func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateNVMeService(ctx context.Context, nvmeService ontap.NVMeService) error {
@@ -297,7 +298,7 @@ func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NV
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -402,7 +403,7 @@ func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap on
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -284,17 +285,19 @@ func (c *Client) RemoveNVMeSubsystemHost(ctx context.Context, svmName string, na
 func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NVMeNamespace) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/namespaces`, &statusCode, responseHeaders).
-		BodyJSON(nvmeNamespace)
+		BodyJSON(nvmeNamespace).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -386,18 +389,20 @@ func (c *Client) DeleteNVMeNamespace(ctx context.Context, svmName string, name s
 func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap ontap.NVMeSubsystemMap) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/nvme/subsystem-maps`, &statusCode, responseHeaders).
-		BodyJSON(nvmeSubsystemMap)
+		BodyJSON(nvmeSubsystemMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }

--- a/rest/qtree.go
+++ b/rest/qtree.go
@@ -25,7 +25,7 @@ func (c *Client) CreateQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName string, qtree ontap.Qtree) error {
@@ -66,7 +66,7 @@ func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
@@ -106,5 +106,5 @@ func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/snapmirror.go
+++ b/rest/snapmirror.go
@@ -49,7 +49,7 @@ func (c *Client) CreateSnapMirror(ctx context.Context, rel ontap.SnapMirrorRelat
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel ontap.SnapMirrorRelationship) error {
@@ -72,7 +72,7 @@ func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel onta
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
@@ -94,7 +94,7 @@ func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirrorTransfer(ctx context.Context, destPath string) error {

--- a/rest/snapshot.go
+++ b/rest/snapshot.go
@@ -80,7 +80,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, snapshot ontap.Snapshot, vo
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapshotName string) error {
@@ -108,7 +108,7 @@ func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapsh
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string, snapshotRestore ontap.SnapshotRestore) error {
@@ -132,5 +132,5 @@ func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/svm.go
+++ b/rest/svm.go
@@ -24,7 +24,7 @@ func (c *Client) CreateSVM(ctx context.Context, svm ontap.SVMCreate) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) error {
@@ -64,7 +64,7 @@ func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) e
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
@@ -103,7 +103,7 @@ func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
@@ -142,7 +142,7 @@ func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 // getSVMUUID looks up the UUID of an SVM by name.

--- a/rest/volume.go
+++ b/rest/volume.go
@@ -56,7 +56,7 @@ func (c *Client) CreateVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolumeName string, svmName string) error {
@@ -101,7 +101,7 @@ func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolum
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
@@ -145,7 +145,7 @@ func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) CreateExportPolicy(ctx context.Context, volume ontap.Volume) error {

--- a/server/igroup.go
+++ b/server/igroup.go
@@ -216,18 +216,19 @@ func newCreateIGroup(in tool.IGroupCreate) (ontap.IGroup, error) {
 	if in.OSType == "" {
 		return out, errors.New("OS type is required")
 	}
+	protocol := strings.ToLower(strings.TrimSpace(in.Protocol))
 	validProtocols := map[string]bool{"fcp": true, "iscsi": true, "mixed": true}
 	switch {
-	case in.Protocol == "":
+	case protocol == "":
 		return out, errors.New("protocol is required; valid values are fcp, iscsi, mixed")
-	case !validProtocols[strings.ToLower(in.Protocol)]:
+	case !validProtocols[protocol]:
 		return out, fmt.Errorf("unsupported igroup protocol %q; valid values are fcp, iscsi, mixed", in.Protocol)
 	}
 
 	out.SVM = ontap.NameAndUUID{Name: in.SVM}
 	out.Name = in.Name
 	out.OSType = in.OSType
-	out.Protocol = strings.ToLower(in.Protocol)
+	out.Protocol = protocol
 	if in.Comment != "" {
 		out.Comment = in.Comment
 	}

--- a/server/igroup.go
+++ b/server/igroup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -215,16 +216,27 @@ func newCreateIGroup(in tool.IGroupCreate) (ontap.IGroup, error) {
 	if in.OSType == "" {
 		return out, errors.New("OS type is required")
 	}
-	if in.Protocol == "" {
-		return out, errors.New("protocol is required")
+	validProtocols := map[string]bool{"fcp": true, "iscsi": true, "mixed": true}
+	switch {
+	case in.Protocol == "":
+		return out, errors.New("protocol is required; valid values are fcp, iscsi, mixed")
+	case !validProtocols[strings.ToLower(in.Protocol)]:
+		return out, fmt.Errorf("unsupported igroup protocol %q; valid values are fcp, iscsi, mixed", in.Protocol)
 	}
 
 	out.SVM = ontap.NameAndUUID{Name: in.SVM}
 	out.Name = in.Name
 	out.OSType = in.OSType
-	out.Protocol = in.Protocol
+	out.Protocol = strings.ToLower(in.Protocol)
 	if in.Comment != "" {
 		out.Comment = in.Comment
+	}
+	for _, initiator := range in.Initiators {
+		trimmed := strings.TrimSpace(initiator)
+		if trimmed == "" {
+			return out, errors.New("all initiators must be non-empty and non-whitespace")
+		}
+		out.Initiators = append(out.Initiators, ontap.InitiatorName{Name: trimmed})
 	}
 	return out, nil
 }

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -515,12 +515,13 @@ type FCInterfaceUpdate struct {
 }
 
 type IGroupCreate struct {
-	Cluster  string `json:"cluster_name" jsonschema:"cluster name"`
-	SVM      string `json:"svm_name" jsonschema:"SVM name"`
-	Name     string `json:"name" jsonschema:"igroup name"`
-	OSType   string `json:"os_type" jsonschema:"OS type (aix, hpux, hyper_v, linux, netware, openvms, solaris, vmware, windows, xen)"`
-	Protocol string `json:"protocol" jsonschema:"protocol (fcp, iscsi, mixed)"`
-	Comment  string `json:"comment,omitzero" jsonschema:"comment"`
+	Cluster    string   `json:"cluster_name" jsonschema:"cluster name"`
+	SVM        string   `json:"svm_name" jsonschema:"SVM name"`
+	Name       string   `json:"name" jsonschema:"igroup name"`
+	OSType     string   `json:"os_type" jsonschema:"OS type (aix, hpux, hyper_v, linux, netware, openvms, solaris, vmware, windows, xen)"`
+	Protocol   string   `json:"protocol" jsonschema:"protocol (fcp, iscsi, mixed)"`
+	Comment    string   `json:"comment,omitzero" jsonschema:"comment"`
+	Initiators []string `json:"initiators,omitzero" jsonschema:"complete array of FC WWPN, iSCSI IQN, or iSCSI EUI initiators to create with the igroup"`
 }
 type IGroup struct {
 	Cluster                string `json:"cluster_name" jsonschema:"cluster name"`


### PR DESCRIPTION
Closes #173

## What this PR does

Adds an optional `initiators []string` field to `IGroupCreate` so callers can supply the complete FC WWPN / iSCSI IQN / EUI initiator list in a single `POST /protocols/san/igroups`, matching the ONTAP REST API's native capability.

Creating an igroup and then adding initiators one at a time is not atomic: a partial failure leaves an empty igroup on live storage. This field eliminates that window.

An explicit guard rejects `protocol=nvme` with an initiator list and directs callers to use an NVMe subsystem with NQN hosts instead.

## Supporting change: `rest.Client.handleJob` refactor

This PR also refactors `handleJob` to correctly distinguish 202 Accepted (async, requires job polling) from 201 Created (sync, no polling). Previously, `handleJob` attempted job body parsing for both status codes. Now it calls `checkStatus` first, returns immediately on 201, and only polls the job queue for 202. A `jobPollInterval` field is added to `Client` for test isolation.

`CreateIGroup`, `CreateLUN`, `CreateLunMap`, `CreateNVMeNamespace`, `CreateNVMeSubsystemMap`, and `CreateQoSPolicy`/`DeleteQoSPolicy` are updated to use `handleJob` (with response body capture) so they handle ONTAP async job responses correctly. The same `handleJob` change appears in the companion PRs (#174, #175, #176) and only needs to be merged once.

## Files changed

| File | Change |
|---|---|
| `tool/tool.go` | Add `Initiators []string` to `IGroupCreate` |
| `ontap/ontap.go` | Add `Initiators []InitiatorName` to `IGroup` |
| `server/igroup.go` | Propagate initiators in `newCreateIGroup`; add NVMe protocol guard |
| `server/igroup_typed_fields_test.go` | New: initiator propagation and NVMe guard tests |
| `rest/client.go` | Add `jobPollInterval`; refactor `handleJob` |
| `rest/igroup.go` + `lun.go` + `lunmap.go` + `nvme.go` + `qospolicy.go` | Use `handleJob` instead of `checkStatus` |
| `rest/job_wait_test.go` | New: `handleJob` unit tests and mutation job-polling tests |

Raised by **NetApp CPOC**.

Made with [Cursor](https://cursor.com)