### PR TITLE
feat: add volume guarantee, snapshot policy, snapshot reserve, and efficiency fields

### DIFF
--- a/integration/test/volume_test.go
+++ b/integration/test/volume_test.go
@@ -113,7 +113,7 @@ func TestVolume(t *testing.T) {
 		{
 			name:             "Clean thick volume",
 			input:            ClusterStr + "delete volume " + rn("thick") + " in " + rn("marketing") + " svm",
-			expectedOntapErr: "because it does not exist",
+			expectedOntapErr: "",
 			verifyAPI:        ontapVerifier{api: "api/storage/volumes?name=" + rn("thick") + "&svm=" + rn("marketing"), validationFunc: deleteObject},
 		},
 		{

--- a/integration/test/volume_test.go
+++ b/integration/test/volume_test.go
@@ -93,6 +93,30 @@ func TestVolume(t *testing.T) {
 			verifyAPI:        ontapVerifier{},
 		},
 		{
+			name:             "Create thick-provisioned volume",
+			input:            ClusterStr + "create a 50MB thick-provisioned volume named " + rn("thick") + " on the " + rn("marketing") + " svm and the harvest_vc_aggr aggregate with space guarantee type volume and snapshot reserve 5 percent",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{api: "api/storage/volumes?name=" + rn("thick") + "&svm=" + rn("marketing"), validationFunc: createObject},
+		},
+		{
+			name:             "Update volume snapshot policy",
+			input:            ClusterStr + "set the snapshot policy of the " + rn("thick") + " volume on the " + rn("marketing") + " svm to none",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{},
+		},
+		{
+			name:             "Update volume efficiency",
+			input:            ClusterStr + "disable compression and deduplication on the " + rn("thick") + " volume on the " + rn("marketing") + " svm",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{},
+		},
+		{
+			name:             "Clean thick volume",
+			input:            ClusterStr + "delete volume " + rn("thick") + " in " + rn("marketing") + " svm",
+			expectedOntapErr: "because it does not exist",
+			verifyAPI:        ontapVerifier{api: "api/storage/volumes?name=" + rn("thick") + "&svm=" + rn("marketing"), validationFunc: deleteObject},
+		},
+		{
 			name:             "Clean volume",
 			input:            ClusterStr + "delete volume " + rn("docs") + " in " + rn("marketing") + " svm",
 			expectedOntapErr: "because it does not exist",

--- a/ontap/ontap.go
+++ b/ontap/ontap.go
@@ -95,6 +95,28 @@ type Autosize struct {
 	ShrinkThreshold string `json:"shrink_threshold,omitzero"`
 }
 
+type VolumeGuarantee struct {
+	Type string `json:"type,omitzero"`
+}
+
+type VolumeSnapshotPolicy struct {
+	Name string `json:"name,omitzero"`
+}
+
+type VolumeSnapshotSpace struct {
+	ReservePercent *int `json:"reserve_percent,omitzero"`
+}
+
+type VolumeSpace struct {
+	Snapshot VolumeSnapshotSpace `json:"snapshot,omitzero"`
+}
+
+type VolumeEfficiency struct {
+	Dedupe            string `json:"dedupe,omitzero"`
+	CrossVolumeDedupe string `json:"cross_volume_dedupe,omitzero"`
+	Compression       string `json:"compression,omitzero"`
+}
+
 type VolumeQoSPolicy struct {
 	Name           string `json:"name,omitzero"`
 	MaxThroughIOPS *int   `json:"max_throughput_iops,omitzero"`
@@ -108,16 +130,20 @@ type VolumeQoS struct {
 }
 
 type Volume struct {
-	SVM        NameAndUUID   `json:"svm,omitzero"`
-	Name       string        `json:"name,omitzero"`
-	Aggregates []NameAndUUID `json:"aggregates,omitzero"`
-	State      string        `json:"state,omitempty"` // enum: error, mixed, offline, online, restricted
-	Style      string        `json:"style,omitempty"` // enum: flexvol, flexgroup, flexgroup_constituent
-	Size       int64         `json:"size,omitempty"`
-	Nas        NAS           `json:"nas,omitzero"`
-	Autosize   Autosize      `json:"autosize,omitzero"`
-	QoS        VolumeQoS     `json:"qos,omitzero"`
-	Type       string        `json:"type,omitzero"` // enum: rw, dp, ls
+	SVM            NameAndUUID          `json:"svm,omitzero"`
+	Name           string               `json:"name,omitzero"`
+	Aggregates     []NameAndUUID        `json:"aggregates,omitzero"`
+	State          string               `json:"state,omitempty"` // enum: error, mixed, offline, online, restricted
+	Style          string               `json:"style,omitempty"` // enum: flexvol, flexgroup, flexgroup_constituent
+	Size           int64                `json:"size,omitempty"`
+	Nas            NAS                  `json:"nas,omitzero"`
+	Autosize       Autosize             `json:"autosize,omitzero"`
+	Guarantee      VolumeGuarantee      `json:"guarantee,omitzero"`
+	SnapshotPolicy VolumeSnapshotPolicy `json:"snapshot_policy,omitzero"`
+	Space          VolumeSpace          `json:"space,omitzero"`
+	Efficiency     VolumeEfficiency     `json:"efficiency,omitzero"`
+	QoS            VolumeQoS            `json:"qos,omitzero"`
+	Type           string               `json:"type,omitzero"` // enum: rw, dp, ls
 }
 
 type NameAndUUID struct {

--- a/rest/cifsService.go
+++ b/rest/cifsService.go
@@ -23,7 +23,7 @@ func (c *Client) CreateCIFSService(ctx context.Context, cifsService ontap.CIFSSe
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsService ontap.CIFSServiceBody) error {
@@ -47,7 +47,7 @@ func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsServ
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassword string) error {
@@ -88,5 +88,5 @@ func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassw
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/client.go
+++ b/rest/client.go
@@ -26,11 +26,12 @@ import (
 )
 
 type Client struct {
-	poller     *config.Poller
-	httpClient *http.Client
-	credCache  credentialsCache
-	remote     ontap.Remote
-	initOnce   sync.Once
+	poller          *config.Poller
+	httpClient      *http.Client
+	credCache       credentialsCache
+	remote          ontap.Remote
+	initOnce        sync.Once
+	jobPollInterval time.Duration
 }
 
 // credentials holds authentication information
@@ -41,28 +42,32 @@ type credentials struct {
 }
 
 func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
-	if statusCode == http.StatusCreated || statusCode == http.StatusAccepted {
-		var pj ontap.PostJob
-		err := json.Unmarshal(buf.Bytes(), &pj)
-		if err != nil {
-			return err
-		}
-
-		err = c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
-		if err != nil {
-			return err
-		}
+	if err := c.checkStatus(statusCode); err != nil {
+		return err
+	}
+	if statusCode != http.StatusAccepted {
+		return nil
 	}
 
-	return nil
+	var pj ontap.PostJob
+	if err := json.Unmarshal(buf.Bytes(), &pj); err != nil {
+		return fmt.Errorf("failed to decode async job response: %w", err)
+	}
+	if strings.TrimSpace(pj.Job.UUID) == "" {
+		return fmt.Errorf("async job response is missing job UUID")
+	}
+
+	return c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
 }
 
 //nolint:unparam
 func (c *Client) waitForJob(ctx context.Context, jobLocation string, duration time.Duration) error {
 	var jr ontap.JobResponse
 
-	// Poll every pollInterval seconds, up to duration
-	const pollInterval = 2 * time.Second
+	pollInterval := c.jobPollInterval
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
 	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -41,7 +41,7 @@ type credentials struct {
 	AuthToken string
 }
 
-func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
+func (c *Client) handleJob(ctx context.Context, statusCode int, buf *bytes.Buffer) error {
 	if err := c.checkStatus(statusCode); err != nil {
 		return err
 	}

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -26,7 +26,7 @@ func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -13,17 +14,19 @@ import (
 func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/igroups`, &statusCode, responseHeaders).
-		BodyJSON(igroup)
+		BodyJSON(igroup).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -12,17 +13,19 @@ import (
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/luns`, &statusCode, responseHeaders).
-		BodyJSON(lun)
+		BodyJSON(lun).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
@@ -25,7 +26,7 @@ func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -10,17 +11,21 @@ import (
 )
 
 func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
-	var statusCode int
+	var (
+		statusCode int
+		buf        bytes.Buffer
+	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/lun-maps`, &statusCode, responseHeaders).
-		BodyJSON(lunMap)
+		BodyJSON(lunMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -25,7 +25,7 @@ func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateNVMeService(ctx context.Context, nvmeService ontap.NVMeService) error {
@@ -297,7 +298,7 @@ func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NV
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -402,7 +403,7 @@ func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap on
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -284,17 +285,19 @@ func (c *Client) RemoveNVMeSubsystemHost(ctx context.Context, svmName string, na
 func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NVMeNamespace) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/namespaces`, &statusCode, responseHeaders).
-		BodyJSON(nvmeNamespace)
+		BodyJSON(nvmeNamespace).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -386,18 +389,20 @@ func (c *Client) DeleteNVMeNamespace(ctx context.Context, svmName string, name s
 func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap ontap.NVMeSubsystemMap) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/nvme/subsystem-maps`, &statusCode, responseHeaders).
-		BodyJSON(nvmeSubsystemMap)
+		BodyJSON(nvmeSubsystemMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }

--- a/rest/qtree.go
+++ b/rest/qtree.go
@@ -25,7 +25,7 @@ func (c *Client) CreateQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName string, qtree ontap.Qtree) error {
@@ -66,7 +66,7 @@ func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
@@ -106,5 +106,5 @@ func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/snapmirror.go
+++ b/rest/snapmirror.go
@@ -49,7 +49,7 @@ func (c *Client) CreateSnapMirror(ctx context.Context, rel ontap.SnapMirrorRelat
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel ontap.SnapMirrorRelationship) error {
@@ -72,7 +72,7 @@ func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel onta
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
@@ -94,7 +94,7 @@ func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirrorTransfer(ctx context.Context, destPath string) error {

--- a/rest/snapshot.go
+++ b/rest/snapshot.go
@@ -80,7 +80,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, snapshot ontap.Snapshot, vo
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapshotName string) error {
@@ -108,7 +108,7 @@ func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapsh
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string, snapshotRestore ontap.SnapshotRestore) error {
@@ -132,5 +132,5 @@ func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/svm.go
+++ b/rest/svm.go
@@ -24,7 +24,7 @@ func (c *Client) CreateSVM(ctx context.Context, svm ontap.SVMCreate) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) error {
@@ -64,7 +64,7 @@ func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) e
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
@@ -103,7 +103,7 @@ func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
@@ -142,7 +142,7 @@ func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 // getSVMUUID looks up the UUID of an SVM by name.

--- a/rest/volume.go
+++ b/rest/volume.go
@@ -56,7 +56,7 @@ func (c *Client) CreateVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolumeName string, svmName string) error {
@@ -101,7 +101,7 @@ func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolum
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
@@ -145,7 +145,7 @@ func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) CreateExportPolicy(ctx context.Context, volume ontap.Volume) error {

--- a/server/volume.go
+++ b/server/volume.go
@@ -236,8 +236,33 @@ func updateVolumeValidation(in tool.VolumeUpdate) (ontap.Volume, error) {
 		}
 	}
 
+	if in.GuaranteeType != "" {
+		out.Guarantee.Type = in.GuaranteeType
+		hasUpdate = true
+	}
+	if in.SnapshotPolicyName != "" {
+		out.SnapshotPolicy.Name = in.SnapshotPolicyName
+		hasUpdate = true
+	}
+	if in.SnapshotReservePercent != nil {
+		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
+		hasUpdate = true
+	}
+	if in.Efficiency.Dedupe != "" {
+		out.Efficiency.Dedupe = in.Efficiency.Dedupe
+		hasUpdate = true
+	}
+	if in.Efficiency.CrossVolumeDedupe != "" {
+		out.Efficiency.CrossVolumeDedupe = in.Efficiency.CrossVolumeDedupe
+		hasUpdate = true
+	}
+	if in.Efficiency.Compression != "" {
+		out.Efficiency.Compression = in.Efficiency.Compression
+		hasUpdate = true
+	}
+
 	if !hasUpdate {
-		return out, errors.New("at least one updatable field must be provided (e.g. new_volume_name, size, state, nas.path, nas.export_policy.name, autosize: mode/maximum/minimum/grow_threshold/shrink_threshold, qos.policy: name/remove_qos_policy/max_iops/min_iops/max_mbps/min_mbps)")
+		return out, errors.New("at least one updatable field must be provided (e.g. new_volume_name, size, state, nas.path, nas.export_policy.name, autosize: mode/maximum/minimum/grow_threshold/shrink_threshold, qos.policy: name/remove_qos_policy/max_iops/min_iops/max_mbps/min_mbps, guarantee.type, snapshot_policy.name, space.snapshot.reserve_percent, efficiency)")
 	}
 
 	return out, nil
@@ -273,6 +298,24 @@ func newCreateVolume(in tool.VolumeCreate) (ontap.Volume, error) {
 
 	if in.Type != "" {
 		out.Type = in.Type
+	}
+	if in.GuaranteeType != "" {
+		out.Guarantee.Type = in.GuaranteeType
+	}
+	if in.SnapshotPolicyName != "" {
+		out.SnapshotPolicy.Name = in.SnapshotPolicyName
+	}
+	if in.SnapshotReservePercent != nil {
+		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
+	}
+	if in.Efficiency.Dedupe != "" {
+		out.Efficiency.Dedupe = in.Efficiency.Dedupe
+	}
+	if in.Efficiency.CrossVolumeDedupe != "" {
+		out.Efficiency.CrossVolumeDedupe = in.Efficiency.CrossVolumeDedupe
+	}
+	if in.Efficiency.Compression != "" {
+		out.Efficiency.Compression = in.Efficiency.Compression
 	}
 
 	if in.ExportPolicy != "" || in.JunctionPath != "" {
@@ -368,6 +411,31 @@ func newUpdateVolume(in tool.Volume) (ontap.Volume, error) {
 		out.Autosize.ShrinkThreshold = in.Autosize.ShrinkThreshold
 		hasUpdate = true
 	}
+	if in.Efficiency.Dedupe != "" {
+		out.Efficiency.Dedupe = in.Efficiency.Dedupe
+		hasUpdate = true
+	}
+	if in.Efficiency.CrossVolumeDedupe != "" {
+		out.Efficiency.CrossVolumeDedupe = in.Efficiency.CrossVolumeDedupe
+		hasUpdate = true
+	}
+	if in.Efficiency.Compression != "" {
+		out.Efficiency.Compression = in.Efficiency.Compression
+		hasUpdate = true
+	}
+
+	if in.GuaranteeType != "" {
+		out.Guarantee.Type = in.GuaranteeType
+		hasUpdate = true
+	}
+	if in.SnapshotPolicyName != "" {
+		out.SnapshotPolicy.Name = in.SnapshotPolicyName
+		hasUpdate = true
+	}
+	if in.SnapshotReservePercent != nil {
+		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
+		hasUpdate = true
+	}
 
 	switch {
 	case in.QoS.RemovePolicy:
@@ -396,7 +464,7 @@ func newUpdateVolume(in tool.Volume) (ontap.Volume, error) {
 	}
 
 	if !hasUpdate {
-		return out, errors.New("at least one updatable field must be provided (e.g. new_volume_name, size, state, nas.path, nas.export_policy.name, autosize: mode/maximum/minimum/grow_threshold/shrink_threshold, qos.policy: name/remove_qos_policy/max_iops/min_iops/max_mbps/min_mbps)")
+		return out, errors.New("at least one updatable field must be provided (e.g. new_volume_name, size, state, nas.path, nas.export_policy.name, autosize: mode/maximum/minimum/grow_threshold/shrink_threshold, qos.policy: name/remove_qos_policy/max_iops/min_iops/max_mbps/min_mbps, guarantee.type, snapshot_policy.name, space.snapshot.reserve_percent, efficiency)")
 	}
 
 	return out, nil

--- a/server/volume.go
+++ b/server/volume.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/netapp/ontap-mcp/ontap"
 	"github.com/netapp/ontap-mcp/tool"
-	"strconv"
-	"strings"
 )
 
 func (a *App) CreateVolume(ctx context.Context, _ *mcp.CallToolRequest, parameters tool.VolumeCreate) (*mcp.CallToolResult, any, error) {
@@ -245,6 +246,9 @@ func updateVolumeValidation(in tool.VolumeUpdate) (ontap.Volume, error) {
 		hasUpdate = true
 	}
 	if in.SnapshotReservePercent != nil {
+		if *in.SnapshotReservePercent < 0 || *in.SnapshotReservePercent > 100 {
+			return out, errors.New("snapshot_reserve_percent must be between 0 and 100")
+		}
 		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
 		hasUpdate = true
 	}
@@ -306,6 +310,9 @@ func newCreateVolume(in tool.VolumeCreate) (ontap.Volume, error) {
 		out.SnapshotPolicy.Name = in.SnapshotPolicyName
 	}
 	if in.SnapshotReservePercent != nil {
+		if *in.SnapshotReservePercent < 0 || *in.SnapshotReservePercent > 100 {
+			return out, errors.New("snapshot_reserve_percent must be between 0 and 100")
+		}
 		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
 	}
 	if in.Efficiency.Dedupe != "" {
@@ -433,6 +440,9 @@ func newUpdateVolume(in tool.Volume) (ontap.Volume, error) {
 		hasUpdate = true
 	}
 	if in.SnapshotReservePercent != nil {
+		if *in.SnapshotReservePercent < 0 || *in.SnapshotReservePercent > 100 {
+			return out, errors.New("snapshot_reserve_percent must be between 0 and 100")
+		}
 		out.Space.Snapshot.ReservePercent = in.SnapshotReservePercent
 		hasUpdate = true
 	}

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -8,30 +8,44 @@ type ListVolume struct {
 type ListClusterParams struct{}
 
 type VolumeCreate struct {
-	Cluster      string    `json:"cluster_name" jsonschema:"cluster name"`
-	SVM          string    `json:"svm_name" jsonschema:"SVM name"`
-	Volume       string    `json:"volume_name" jsonschema:"volume name"`
-	Aggregate    string    `json:"aggregate_name" jsonschema:"aggregate name"`
-	JunctionPath string    `json:"nas.path,omitzero" jsonschema:"junction path"`
-	Size         string    `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
-	ExportPolicy string    `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name. Will be created if it doesn't exist"`
-	QoS          VolumeQoS `json:"qos,omitzero" jsonschema:"QoS settings: use policy_name to assign an existing policy, or max_iops/min_iops/max_mbps/min_mbps for inline limits (mutually exclusive)"`
-	Type         string    `json:"type,omitzero" jsonschema:"type of volume (e.g., 'rw', 'dp', 'ls')"`
+	Cluster                string           `json:"cluster_name" jsonschema:"cluster name"`
+	SVM                    string           `json:"svm_name" jsonschema:"SVM name"`
+	Volume                 string           `json:"volume_name" jsonschema:"volume name"`
+	Aggregate              string           `json:"aggregate_name" jsonschema:"aggregate name"`
+	JunctionPath           string           `json:"nas.path,omitzero" jsonschema:"junction path"`
+	Size                   string           `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
+	ExportPolicy           string           `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name. Will be created if it doesn't exist"`
+	QoS                    VolumeQoS        `json:"qos,omitzero" jsonschema:"QoS settings: use policy_name to assign an existing policy, or max_iops/min_iops/max_mbps/min_mbps for inline limits (mutually exclusive)"`
+	Type                   string           `json:"type,omitzero" jsonschema:"type of volume (e.g., 'rw', 'dp', 'ls')"`
+	GuaranteeType          string           `json:"guarantee.type,omitzero" jsonschema:"volume space guarantee type (e.g., 'volume' for thick, 'none' for thin)"`
+	SnapshotPolicyName     string           `json:"snapshot_policy.name,omitzero" jsonschema:"snapshot policy name (e.g., 'none')"`
+	SnapshotReservePercent *int             `json:"space.snapshot.reserve_percent,omitzero" jsonschema:"percentage of volume space reserved for snapshots (e.g., 5)"`
+	Efficiency             VolumeEfficiency `json:"efficiency,omitzero" jsonschema:"volume storage efficiency settings"`
 }
 
 type Volume struct {
-	Cluster      string    `json:"cluster_name" jsonschema:"cluster name"`
-	SVM          string    `json:"svm_name" jsonschema:"SVM name"`
-	Volume       string    `json:"volume_name" jsonschema:"volume name"`
-	Aggregate    string    `json:"aggregate_name,omitzero" jsonschema:"aggregate name"`
-	JunctionPath string    `json:"nas.path,omitzero" jsonschema:"junction path"`
-	NewVolume    string    `json:"new_volume_name,omitzero" jsonschema:"new volume name"`
-	Size         string    `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
-	State        string    `json:"state,omitzero" jsonschema:"state of the volume (e.g., 'online', 'offline')"`
-	ExportPolicy string    `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name. Will be created if it doesn't exist"`
-	Autosize     Autosize  `json:"autosize,omitzero" jsonschema:"autosize"`
-	QoS          VolumeQoS `json:"qos,omitzero" jsonschema:"QoS settings: use policy_name to assign an existing policy, or max_iops/min_iops/max_mbps/min_mbps for inline limits (mutually exclusive)"`
-	Type         string    `json:"type,omitzero" jsonschema:"type of volume (e.g., 'rw', 'dp', 'ls')"`
+	Cluster                string           `json:"cluster_name" jsonschema:"cluster name"`
+	SVM                    string           `json:"svm_name" jsonschema:"SVM name"`
+	Volume                 string           `json:"volume_name" jsonschema:"volume name"`
+	Aggregate              string           `json:"aggregate_name,omitzero" jsonschema:"aggregate name"`
+	GuaranteeType          string           `json:"guarantee.type,omitzero" jsonschema:"volume space guarantee type (e.g., 'volume' for thick, 'none' for thin)"`
+	SnapshotPolicyName     string           `json:"snapshot_policy.name,omitzero" jsonschema:"snapshot policy name (e.g., 'none')"`
+	SnapshotReservePercent *int             `json:"space.snapshot.reserve_percent,omitzero" jsonschema:"percentage of volume space reserved for snapshots (e.g., 5)"`
+	JunctionPath           string           `json:"nas.path,omitzero" jsonschema:"junction path"`
+	NewVolume              string           `json:"new_volume_name,omitzero" jsonschema:"new volume name"`
+	Size                   string           `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
+	State                  string           `json:"state,omitzero" jsonschema:"state of the volume (e.g., 'online', 'offline')"`
+	ExportPolicy           string           `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name. Will be created if it doesn't exist"`
+	Autosize               Autosize         `json:"autosize,omitzero" jsonschema:"autosize"`
+	Efficiency             VolumeEfficiency `json:"efficiency,omitzero" jsonschema:"volume storage efficiency settings"`
+	QoS                    VolumeQoS        `json:"qos,omitzero" jsonschema:"QoS settings: use policy_name to assign an existing policy, or max_iops/min_iops/max_mbps/min_mbps for inline limits (mutually exclusive)"`
+	Type                   string           `json:"type,omitzero" jsonschema:"type of volume (e.g., 'rw', 'dp', 'ls')"`
+}
+
+type VolumeEfficiency struct {
+	Dedupe            string `json:"dedupe,omitzero" jsonschema:"deduplication setting (e.g., 'none')"`
+	CrossVolumeDedupe string `json:"cross_volume_dedupe,omitzero" jsonschema:"cross-volume deduplication setting (e.g., 'none')"`
+	Compression       string `json:"compression,omitzero" jsonschema:"compression setting (e.g., 'none')"`
 }
 
 type VolumeModify struct {
@@ -43,13 +57,17 @@ type VolumeModify struct {
 }
 
 type VolumeUpdate struct {
-	NewVolume    string    `json:"new_volume_name,omitzero" jsonschema:"new volume name for rename operation"`
-	Size         string    `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
-	State        string    `json:"state,omitzero" jsonschema:"state of the volume (e.g., 'online', 'offline')"`
-	JunctionPath string    `json:"nas.path,omitzero" jsonschema:"junction path"`
-	ExportPolicy string    `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name"`
-	Autosize     Autosize  `json:"autosize,omitzero" jsonschema:"autosize"`
-	QoS          VolumeQoS `json:"qos,omitzero" jsonschema:"QoS settings"`
+	NewVolume              string           `json:"new_volume_name,omitzero" jsonschema:"new volume name for rename operation"`
+	Size                   string           `json:"size,omitzero" jsonschema:"size of the volume (e.g., '100GB', '1TB')"`
+	State                  string           `json:"state,omitzero" jsonschema:"state of the volume (e.g., 'online', 'offline')"`
+	JunctionPath           string           `json:"nas.path,omitzero" jsonschema:"junction path"`
+	ExportPolicy           string           `json:"nas.export_policy.name,omitzero" jsonschema:"nfs export policy name"`
+	Autosize               Autosize         `json:"autosize,omitzero" jsonschema:"autosize"`
+	QoS                    VolumeQoS        `json:"qos,omitzero" jsonschema:"QoS settings"`
+	GuaranteeType          string           `json:"guarantee.type,omitzero" jsonschema:"volume space guarantee type (e.g., 'volume' for thick, 'none' for thin)"`
+	SnapshotPolicyName     string           `json:"snapshot_policy.name,omitzero" jsonschema:"snapshot policy name (e.g., 'none')"`
+	SnapshotReservePercent *int             `json:"space.snapshot.reserve_percent,omitzero" jsonschema:"percentage of volume space reserved for snapshots (e.g., 5)"`
+	Efficiency             VolumeEfficiency `json:"efficiency,omitzero" jsonschema:"volume storage efficiency settings"`
 }
 
 type VolumeQoS struct {


### PR DESCRIPTION
Closes #174

## What this PR does

Extends `create_volume` with three fields required for thick-provisioned SAN workloads that cannot be assumed from cluster defaults:

| New field | ONTAP REST path | Example |
|---|---|---|
| `guarantee_type` | `guarantee.type` | `"volume"` |
| `snapshot_policy_name` | `snapshot_policy.name` | `"none"` |
| `snapshot_reserve_percent` | `space.snapshot.reserve_percent` | `0` |

Extends `update_volume` with an `efficiency` nested object (`dedupe`, `cross_volume_dedupe`, `compression`) so callers can disable inline storage efficiency on a provisioned volume without a raw PATCH.

All fields are omitted from the REST body when zero/nil, preserving existing behavior.

## Supporting change: `rest.Client.handleJob` refactor

Includes the same `handleJob` refactor as PR #178 (correctly distinguishes 201 Created from 202 Accepted). Only needs to be merged once across the four companion PRs.

## Files changed

| File | Change |
|---|---|
| `tool/tool.go` | Add `GuaranteeType`, `SnapshotPolicyName`, `SnapshotReservePercent`, `Efficiency VolumeEfficiency` to `Volume`; add `VolumeEfficiency` struct |
| `ontap/ontap.go` | Add `VolumeGuarantee`, `VolumeSnapshotPolicy`, `VolumeSnapshotSpace`, `VolumeSpace`, `VolumeEfficiency` structs; extend `Volume` |
| `server/volume.go` | Propagate new fields in `newCreateVolume` and `newUpdateVolume` |
| `server/volume_typed_fields_test.go` | New: guarantee/snapshot/efficiency field propagation tests |
| `rest/client.go` + `rest/*.go` + `rest/job_wait_test.go` | `handleJob` refactor (same as #178) |

Raised by **NetApp CPOC**.

Made with [Cursor](https://cursor.com)