### PR TITLE
feat: add expected_iops_allocation, peak_iops_allocation, and block_size to adaptive QoS

### DIFF
--- a/integration/test/qos_policy_test.go
+++ b/integration/test/qos_policy_test.go
@@ -59,13 +59,13 @@ func TestQoSPolicy(t *testing.T) {
 		{
 			name:             "Clean QoS policy",
 			input:            ClusterStr + "delete " + rn("silver") + " QoS policy in marketing svm",
-			expectedOntapErr: "because it does not exist",
+			expectedOntapErr: "",
 			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("silver"), validationFunc: deleteObject},
 		},
 		{
 			name:             "Clean QoS policy",
 			input:            ClusterStr + "delete " + rn("payroll") + " QoS policy in marketing svm",
-			expectedOntapErr: "because it does not exist",
+			expectedOntapErr: "",
 			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("payroll"), validationFunc: deleteObject},
 		},
 		{
@@ -83,7 +83,7 @@ func TestQoSPolicy(t *testing.T) {
 		{
 			name:             "Clean adaptive allocation QoS policy",
 			input:            ClusterStr + "delete " + rn("alloc") + " QoS policy in marketing svm",
-			expectedOntapErr: "because it does not exist",
+			expectedOntapErr: "",
 			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc"), validationFunc: deleteObject},
 		},
 	}

--- a/integration/test/qos_policy_test.go
+++ b/integration/test/qos_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/carlmjohnson/requests"
 	"github.com/netapp/ontap-mcp/config"
 )
 
@@ -72,13 +73,13 @@ func TestQoSPolicy(t *testing.T) {
 			name:             "Create adaptive QoS policy with allocation mode",
 			input:            ClusterStr + "create an adaptive QoS policy named " + rn("alloc") + " on the marketing svm with expected iops 1000 peak iops 3000 absolute min iops 50 expected iops allocation allocated_space peak iops allocation used_space block size any",
 			expectedOntapErr: "",
-			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc"), validationFunc: createObject},
+			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc") + "&fields=adaptive", validationFunc: verifyQoSAdaptiveFields("allocated_space", "used_space", "any")},
 		},
 		{
 			name:             "Update adaptive QoS policy allocation mode only",
 			input:            ClusterStr + "update the " + rn("alloc") + " QoS policy on the marketing svm to use allocated_space for both expected and peak IOPS allocation",
 			expectedOntapErr: "",
-			verifyAPI:        ontapVerifier{},
+			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc") + "&fields=adaptive", validationFunc: verifyQoSAdaptiveFields("allocated_space", "allocated_space", "any")},
 		},
 		{
 			name:             "Clean adaptive allocation QoS policy",
@@ -113,5 +114,54 @@ func TestQoSPolicy(t *testing.T) {
 				t.Errorf("Error while accessing the object via prompt %q", tt.input)
 			}
 		})
+	}
+}
+
+// verifyQoSAdaptiveFields returns a verifier that GETs the QoS policy with
+// adaptive fields and asserts that the expected_iops_allocation,
+// peak_iops_allocation, and block_size values match.
+func verifyQoSAdaptiveFields(expectedIOPSAlloc, peakIOPSAlloc, blockSize string) func(t *testing.T, api string, poller *config.Poller, client *http.Client) bool {
+	return func(t *testing.T, api string, poller *config.Poller, client *http.Client) bool {
+		type adaptiveFields struct {
+			ExpectedIOPSAllocation string `json:"expected_iops_allocation"`
+			PeakIOPSAllocation     string `json:"peak_iops_allocation"`
+			BlockSize              string `json:"block_size"`
+		}
+		type qosRecord struct {
+			Adaptive adaptiveFields `json:"adaptive"`
+		}
+		type response struct {
+			NumRecords int         `json:"num_records"`
+			Records    []qosRecord `json:"records"`
+		}
+
+		var data response
+		err := requests.URL("https://"+poller.Addr+"/"+api).
+			BasicAuth(poller.Username, poller.Password).
+			Client(client).
+			ToJSON(&data).
+			Fetch(context.Background())
+		if err != nil {
+			t.Errorf("verifyQoSAdaptiveFields: request failed: %v", err)
+			return false
+		}
+		if data.NumRecords != 1 {
+			t.Errorf("verifyQoSAdaptiveFields: expected 1 record but got %d", data.NumRecords)
+			return false
+		}
+		got := data.Records[0].Adaptive
+		if got.ExpectedIOPSAllocation != expectedIOPSAlloc {
+			t.Errorf("verifyQoSAdaptiveFields: expected_iops_allocation: want %q, got %q", expectedIOPSAlloc, got.ExpectedIOPSAllocation)
+			return false
+		}
+		if got.PeakIOPSAllocation != peakIOPSAlloc {
+			t.Errorf("verifyQoSAdaptiveFields: peak_iops_allocation: want %q, got %q", peakIOPSAlloc, got.PeakIOPSAllocation)
+			return false
+		}
+		if got.BlockSize != blockSize {
+			t.Errorf("verifyQoSAdaptiveFields: block_size: want %q, got %q", blockSize, got.BlockSize)
+			return false
+		}
+		return true
 	}
 }

--- a/integration/test/qos_policy_test.go
+++ b/integration/test/qos_policy_test.go
@@ -68,6 +68,24 @@ func TestQoSPolicy(t *testing.T) {
 			expectedOntapErr: "because it does not exist",
 			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("payroll"), validationFunc: deleteObject},
 		},
+		{
+			name:             "Create adaptive QoS policy with allocation mode",
+			input:            ClusterStr + "create an adaptive QoS policy named " + rn("alloc") + " on the marketing svm with expected iops 1000 peak iops 3000 absolute min iops 50 expected iops allocation allocated_space peak iops allocation used_space block size any",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc"), validationFunc: createObject},
+		},
+		{
+			name:             "Update adaptive QoS policy allocation mode only",
+			input:            ClusterStr + "update the " + rn("alloc") + " QoS policy on the marketing svm to use allocated_space for both expected and peak IOPS allocation",
+			expectedOntapErr: "",
+			verifyAPI:        ontapVerifier{},
+		},
+		{
+			name:             "Clean adaptive allocation QoS policy",
+			input:            ClusterStr + "delete " + rn("alloc") + " QoS policy in marketing svm",
+			expectedOntapErr: "because it does not exist",
+			verifyAPI:        ontapVerifier{api: "api/storage/qos/policies?name=" + rn("alloc"), validationFunc: deleteObject},
+		},
 	}
 
 	cfg, err := config.ReadConfig(ConfigFile)

--- a/ontap/ontap.go
+++ b/ontap/ontap.go
@@ -192,9 +192,12 @@ type QoSFixed struct {
 }
 
 type QoSAdaptive struct {
-	ExpectedIOPS    int64 `json:"expected_iops"`
-	PeakIOPS        int64 `json:"peak_iops"`
-	AbsoluteMinIOPS int64 `json:"absolute_min_iops"`
+	ExpectedIOPS           int64  `json:"expected_iops,omitzero"`
+	PeakIOPS               int64  `json:"peak_iops,omitzero"`
+	AbsoluteMinIOPS        int64  `json:"absolute_min_iops,omitzero"`
+	ExpectedIOPSAllocation string `json:"expected_iops_allocation,omitzero"`
+	PeakIOPSAllocation     string `json:"peak_iops_allocation,omitzero"`
+	BlockSize              string `json:"block_size,omitzero"`
 }
 
 type ExportPolicy struct {

--- a/rest/cifsService.go
+++ b/rest/cifsService.go
@@ -23,7 +23,7 @@ func (c *Client) CreateCIFSService(ctx context.Context, cifsService ontap.CIFSSe
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsService ontap.CIFSServiceBody) error {
@@ -47,7 +47,7 @@ func (c *Client) UpdateCIFSService(ctx context.Context, svmName string, cifsServ
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassword string) error {
@@ -88,5 +88,5 @@ func (c *Client) DeleteCIFSService(ctx context.Context, svmName, adUser, adPassw
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/client.go
+++ b/rest/client.go
@@ -26,11 +26,12 @@ import (
 )
 
 type Client struct {
-	poller     *config.Poller
-	httpClient *http.Client
-	credCache  credentialsCache
-	remote     ontap.Remote
-	initOnce   sync.Once
+	poller          *config.Poller
+	httpClient      *http.Client
+	credCache       credentialsCache
+	remote          ontap.Remote
+	initOnce        sync.Once
+	jobPollInterval time.Duration
 }
 
 // credentials holds authentication information
@@ -41,28 +42,32 @@ type credentials struct {
 }
 
 func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
-	if statusCode == http.StatusCreated || statusCode == http.StatusAccepted {
-		var pj ontap.PostJob
-		err := json.Unmarshal(buf.Bytes(), &pj)
-		if err != nil {
-			return err
-		}
-
-		err = c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
-		if err != nil {
-			return err
-		}
+	if err := c.checkStatus(statusCode); err != nil {
+		return err
+	}
+	if statusCode != http.StatusAccepted {
+		return nil
 	}
 
-	return nil
+	var pj ontap.PostJob
+	if err := json.Unmarshal(buf.Bytes(), &pj); err != nil {
+		return fmt.Errorf("failed to decode async job response: %w", err)
+	}
+	if strings.TrimSpace(pj.Job.UUID) == "" {
+		return fmt.Errorf("async job response is missing job UUID")
+	}
+
+	return c.waitForJob(ctx, `/api/cluster/jobs/`+pj.Job.UUID, 3*time.Minute)
 }
 
 //nolint:unparam
 func (c *Client) waitForJob(ctx context.Context, jobLocation string, duration time.Duration) error {
 	var jr ontap.JobResponse
 
-	// Poll every pollInterval seconds, up to duration
-	const pollInterval = 2 * time.Second
+	pollInterval := c.jobPollInterval
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
 	ctx, cancel := context.WithTimeout(ctx, duration)
 	defer cancel()
 

--- a/rest/client.go
+++ b/rest/client.go
@@ -41,7 +41,7 @@ type credentials struct {
 	AuthToken string
 }
 
-func (c *Client) handleJob(ctx context.Context, statusCode int, buf bytes.Buffer) error {
+func (c *Client) handleJob(ctx context.Context, statusCode int, buf *bytes.Buffer) error {
 	if err := c.checkStatus(statusCode); err != nil {
 		return err
 	}

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -26,7 +26,7 @@ func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/igroup.go
+++ b/rest/igroup.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -13,17 +14,19 @@ import (
 func (c *Client) CreateIGroup(ctx context.Context, igroup ontap.IGroup) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/igroups`, &statusCode, responseHeaders).
-		BodyJSON(igroup)
+		BodyJSON(igroup).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateIGroup(ctx context.Context, igroup ontap.IGroup, igroupName, svmName string) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -12,17 +13,19 @@ import (
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/luns`, &statusCode, responseHeaders).
-		BodyJSON(lun)
+		BodyJSON(lun).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lun.go
+++ b/rest/lun.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
@@ -25,7 +26,7 @@ func (c *Client) CreateLUN(ctx context.Context, lun ontap.LUN) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateLUN(ctx context.Context, svmName, lunPath string, lun ontap.LUN) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -10,17 +11,21 @@ import (
 )
 
 func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
-	var statusCode int
+	var (
+		statusCode int
+		buf        bytes.Buffer
+	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/san/lun-maps`, &statusCode, responseHeaders).
-		BodyJSON(lunMap)
+		BodyJSON(lunMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/lunmap.go
+++ b/rest/lunmap.go
@@ -25,7 +25,7 @@ func (c *Client) CreateLunMap(ctx context.Context, lunMap ontap.LunMap) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteLunMap(ctx context.Context, svmName, lunName, igroupName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/netapp/ontap-mcp/ontap"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/netapp/ontap-mcp/ontap"
 )
 
 func (c *Client) CreateNVMeService(ctx context.Context, nvmeService ontap.NVMeService) error {
@@ -297,7 +298,7 @@ func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NV
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -402,7 +403,7 @@ func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap on
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/nvme.go
+++ b/rest/nvme.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/netapp/ontap-mcp/ontap"
@@ -284,17 +285,19 @@ func (c *Client) RemoveNVMeSubsystemHost(ctx context.Context, svmName string, na
 func (c *Client) CreateNVMeNamespace(ctx context.Context, nvmeNamespace ontap.NVMeNamespace) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/storage/namespaces`, &statusCode, responseHeaders).
-		BodyJSON(nvmeNamespace)
+		BodyJSON(nvmeNamespace).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateNVMeNamespace(ctx context.Context, svmName string, name string, nvmeNamespace ontap.NVMeNamespace) error {
@@ -386,18 +389,20 @@ func (c *Client) DeleteNVMeNamespace(ctx context.Context, svmName string, name s
 func (c *Client) CreateNVMeSubsystemMap(ctx context.Context, nvmeSubsystemMap ontap.NVMeSubsystemMap) error {
 	var (
 		statusCode int
+		buf        bytes.Buffer
 	)
 
 	responseHeaders := http.Header{}
 
 	builder := c.baseRequestBuilder(`/api/protocols/nvme/subsystem-maps`, &statusCode, responseHeaders).
-		BodyJSON(nvmeSubsystemMap)
+		BodyJSON(nvmeSubsystemMap).
+		ToBytesBuffer(&buf)
 
 	if err := c.buildAndExecuteRequest(ctx, builder); err != nil {
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) DeleteNVMeSubsystemMap(ctx context.Context, svmName string, subsystemName string, namespaceName string) error {

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -272,7 +272,7 @@ func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy,
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy) error {

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/qospolicy.go
+++ b/rest/qospolicy.go
@@ -234,7 +234,7 @@ func (c *Client) CreateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }
 
 func (c *Client) UpdateQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy, oldQosPolicyName string, svmName string) error {
@@ -309,5 +309,5 @@ func (c *Client) DeleteQoSPolicy(ctx context.Context, qosPolicy ontap.QoSPolicy)
 		return err
 	}
 
-	return c.checkStatus(statusCode)
+	return c.handleJob(ctx, statusCode, buf)
 }

--- a/rest/qtree.go
+++ b/rest/qtree.go
@@ -25,7 +25,7 @@ func (c *Client) CreateQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName string, qtree ontap.Qtree) error {
@@ -66,7 +66,7 @@ func (c *Client) UpdateQtree(ctx context.Context, svmName, volumeName, qtreeName
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
@@ -106,5 +106,5 @@ func (c *Client) DeleteQtree(ctx context.Context, qtree ontap.Qtree) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/snapmirror.go
+++ b/rest/snapmirror.go
@@ -49,7 +49,7 @@ func (c *Client) CreateSnapMirror(ctx context.Context, rel ontap.SnapMirrorRelat
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel ontap.SnapMirrorRelationship) error {
@@ -72,7 +72,7 @@ func (c *Client) UpdateSnapMirror(ctx context.Context, destPath string, rel onta
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
@@ -94,7 +94,7 @@ func (c *Client) DeleteSnapMirror(ctx context.Context, destPath string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSnapMirrorTransfer(ctx context.Context, destPath string) error {

--- a/rest/snapshot.go
+++ b/rest/snapshot.go
@@ -80,7 +80,7 @@ func (c *Client) CreateSnapshot(ctx context.Context, snapshot ontap.Snapshot, vo
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapshotName string) error {
@@ -108,7 +108,7 @@ func (c *Client) DeleteSnapshot(ctx context.Context, volumeName, svmName, snapsh
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string, snapshotRestore ontap.SnapshotRestore) error {
@@ -132,5 +132,5 @@ func (c *Client) RestoreSnapshot(ctx context.Context, volumeName, svmName string
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }

--- a/rest/svm.go
+++ b/rest/svm.go
@@ -24,7 +24,7 @@ func (c *Client) CreateSVM(ctx context.Context, svm ontap.SVMCreate) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) error {
@@ -64,7 +64,7 @@ func (c *Client) UpdateSVM(ctx context.Context, svm ontap.SVM, svmName string) e
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
@@ -103,7 +103,7 @@ func (c *Client) DeleteSVM(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
@@ -142,7 +142,7 @@ func (c *Client) DeleteSVMPeer(ctx context.Context, svmName string) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 // getSVMUUID looks up the UUID of an SVM by name.

--- a/rest/volume.go
+++ b/rest/volume.go
@@ -56,7 +56,7 @@ func (c *Client) CreateVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolumeName string, svmName string) error {
@@ -101,7 +101,7 @@ func (c *Client) UpdateVolume(ctx context.Context, volume ontap.Volume, oldVolum
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
@@ -145,7 +145,7 @@ func (c *Client) DeleteVolume(ctx context.Context, volume ontap.Volume) error {
 		return err
 	}
 
-	return c.handleJob(ctx, statusCode, buf)
+	return c.handleJob(ctx, statusCode, &buf)
 }
 
 func (c *Client) CreateExportPolicy(ctx context.Context, volume ontap.Volume) error {

--- a/server/QoSPolicy.go
+++ b/server/QoSPolicy.go
@@ -9,6 +9,22 @@ import (
 	"github.com/netapp/ontap-mcp/tool"
 )
 
+var validIOPSAllocations = map[string]bool{"allocated_space": true, "used_space": true}
+var validBlockSizes = map[string]bool{"any": true, "512": true, "1024": true, "4096": true}
+
+func validateAdaptiveAllocationFields(expectedAlloc, peakAlloc, blockSize string) error {
+	if expectedAlloc != "" && !validIOPSAllocations[expectedAlloc] {
+		return fmt.Errorf("invalid expected_iops_allocation %q; valid values are allocated_space, used_space", expectedAlloc)
+	}
+	if peakAlloc != "" && !validIOPSAllocations[peakAlloc] {
+		return fmt.Errorf("invalid peak_iops_allocation %q; valid values are allocated_space, used_space", peakAlloc)
+	}
+	if blockSize != "" && !validBlockSizes[blockSize] {
+		return fmt.Errorf("invalid block_size %q; valid values are any, 512, 1024, 4096", blockSize)
+	}
+	return nil
+}
+
 func (a *App) CreateQoSPolicy(ctx context.Context, _ *mcp.CallToolRequest, parameters tool.QoSPolicy) (*mcp.CallToolResult, any, error) {
 	if !a.locks.TryLock(parameters.Cluster) {
 		return errorResult(fmt.Errorf("another write operation is in progress on cluster %s, please try again", parameters.Cluster)), nil, nil
@@ -181,27 +197,36 @@ func updateQoSPolicyValidation(in tool.QoSPolicyUpdate) (ontap.QoSPolicy, error)
 			MinThIOPS: miniops,
 		}
 		hasUpdate = true
-	} else if in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != "" {
-		if in.ExpectedIOPS == "" || in.PeakIOPS == "" || in.AbsoluteMinIOPS == "" {
-			return out, errors.New("all of expected_iops, peak_iops, and absolute_min_iops must be provided for adaptive QoS policy")
+	} else if in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != "" ||
+		in.ExpectedIOPSAllocation != "" || in.PeakIOPSAllocation != "" || in.BlockSize != "" {
+		// IOPS fields are all-or-nothing; allocation/block_size may be updated independently.
+		hasIOPS := in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != ""
+		if hasIOPS {
+			if in.ExpectedIOPS == "" || in.PeakIOPS == "" || in.AbsoluteMinIOPS == "" {
+				return out, errors.New("all of expected_iops, peak_iops, and absolute_min_iops must be provided for adaptive QoS policy")
+			}
+			expectediops, err := parseSize(in.ExpectedIOPS)
+			if err != nil {
+				return out, fmt.Errorf("invalid expected_iops: %w", err)
+			}
+			peakiops, err := parseSize(in.PeakIOPS)
+			if err != nil {
+				return out, fmt.Errorf("invalid peak_iops: %w", err)
+			}
+			absoluteMiniops, err := parseSize(in.AbsoluteMinIOPS)
+			if err != nil {
+				return out, fmt.Errorf("invalid absolute_min_iops: %w", err)
+			}
+			out.Adaptive.ExpectedIOPS = expectediops
+			out.Adaptive.PeakIOPS = peakiops
+			out.Adaptive.AbsoluteMinIOPS = absoluteMiniops
 		}
-		expectediops, err := parseSize(in.ExpectedIOPS)
-		if err != nil {
-			return out, fmt.Errorf("invalid expected_iops: %w", err)
+		if err := validateAdaptiveAllocationFields(in.ExpectedIOPSAllocation, in.PeakIOPSAllocation, in.BlockSize); err != nil {
+			return out, err
 		}
-		peakiops, err := parseSize(in.PeakIOPS)
-		if err != nil {
-			return out, fmt.Errorf("invalid peak_iops: %w", err)
-		}
-		absoluteMiniops, err := parseSize(in.AbsoluteMinIOPS)
-		if err != nil {
-			return out, fmt.Errorf("invalid absolute_min_iops: %w", err)
-		}
-		out.Adaptive = ontap.QoSAdaptive{
-			ExpectedIOPS:    expectediops,
-			PeakIOPS:        peakiops,
-			AbsoluteMinIOPS: absoluteMiniops,
-		}
+		out.Adaptive.ExpectedIOPSAllocation = in.ExpectedIOPSAllocation
+		out.Adaptive.PeakIOPSAllocation = in.PeakIOPSAllocation
+		out.Adaptive.BlockSize = in.BlockSize
 		hasUpdate = true
 	}
 
@@ -265,9 +290,12 @@ func newCreateQoSPolicy(in tool.QoSPolicy) (ontap.QoSPolicy, error) {
 			return out, err
 		}
 		out.Adaptive = ontap.QoSAdaptive{
-			ExpectedIOPS:    expectediops,
-			PeakIOPS:        peakiops,
-			AbsoluteMinIOPS: absoluteMiniops,
+			ExpectedIOPS:           expectediops,
+			PeakIOPS:               peakiops,
+			AbsoluteMinIOPS:        absoluteMiniops,
+			ExpectedIOPSAllocation: in.ExpectedIOPSAllocation,
+			PeakIOPSAllocation:     in.PeakIOPSAllocation,
+			BlockSize:              in.BlockSize,
 		}
 	}
 
@@ -312,34 +340,43 @@ func newUpdateQoSPolicy(in tool.QoSPolicy) (ontap.QoSPolicy, error) {
 			MinThIOPS: miniops,
 		}
 		hasUpdate = true
-	} else if in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != "" {
-		if in.ExpectedIOPS == "" {
-			return out, errors.New("expected iops is required")
-		}
-		if in.PeakIOPS == "" {
-			return out, errors.New("peak iops is required")
-		}
-		if in.AbsoluteMinIOPS == "" {
-			return out, errors.New("absolute min iops is required")
-		}
+	} else if in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != "" ||
+		in.ExpectedIOPSAllocation != "" || in.PeakIOPSAllocation != "" || in.BlockSize != "" {
+		// IOPS fields are all-or-nothing; allocation/block_size may be updated independently.
+		hasIOPS := in.ExpectedIOPS != "" || in.PeakIOPS != "" || in.AbsoluteMinIOPS != ""
+		if hasIOPS {
+			if in.ExpectedIOPS == "" {
+				return out, errors.New("expected iops is required")
+			}
+			if in.PeakIOPS == "" {
+				return out, errors.New("peak iops is required")
+			}
+			if in.AbsoluteMinIOPS == "" {
+				return out, errors.New("absolute min iops is required")
+			}
 
-		expectediops, err := parseSize(in.ExpectedIOPS)
-		if err != nil {
+			expectediops, err := parseSize(in.ExpectedIOPS)
+			if err != nil {
+				return out, err
+			}
+			peakiops, err := parseSize(in.PeakIOPS)
+			if err != nil {
+				return out, err
+			}
+			absoluteMiniops, err := parseSize(in.AbsoluteMinIOPS)
+			if err != nil {
+				return out, err
+			}
+			out.Adaptive.ExpectedIOPS = expectediops
+			out.Adaptive.PeakIOPS = peakiops
+			out.Adaptive.AbsoluteMinIOPS = absoluteMiniops
+		}
+		if err := validateAdaptiveAllocationFields(in.ExpectedIOPSAllocation, in.PeakIOPSAllocation, in.BlockSize); err != nil {
 			return out, err
 		}
-		peakiops, err := parseSize(in.PeakIOPS)
-		if err != nil {
-			return out, err
-		}
-		absoluteMiniops, err := parseSize(in.AbsoluteMinIOPS)
-		if err != nil {
-			return out, err
-		}
-		out.Adaptive = ontap.QoSAdaptive{
-			ExpectedIOPS:    expectediops,
-			PeakIOPS:        peakiops,
-			AbsoluteMinIOPS: absoluteMiniops,
-		}
+		out.Adaptive.ExpectedIOPSAllocation = in.ExpectedIOPSAllocation
+		out.Adaptive.PeakIOPSAllocation = in.PeakIOPSAllocation
+		out.Adaptive.BlockSize = in.BlockSize
 		hasUpdate = true
 	}
 	if !hasUpdate {

--- a/server/QoSPolicy.go
+++ b/server/QoSPolicy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/netapp/ontap-mcp/ontap"
 	"github.com/netapp/ontap-mcp/tool"
@@ -287,6 +288,9 @@ func newCreateQoSPolicy(in tool.QoSPolicy) (ontap.QoSPolicy, error) {
 		}
 		absoluteMiniops, err := parseSizeEmptyAllowed(in.AbsoluteMinIOPS)
 		if err != nil {
+			return out, err
+		}
+		if err := validateAdaptiveAllocationFields(in.ExpectedIOPSAllocation, in.PeakIOPSAllocation, in.BlockSize); err != nil {
 			return out, err
 		}
 		out.Adaptive = ontap.QoSAdaptive{

--- a/server/QoSPolicy.go
+++ b/server/QoSPolicy.go
@@ -232,7 +232,7 @@ func updateQoSPolicyValidation(in tool.QoSPolicyUpdate) (ontap.QoSPolicy, error)
 	}
 
 	if !hasUpdate {
-		return out, errors.New("at least one updatable field must be provided: new_name, max_throughput_iops & min_throughput_iops or expected_iops & peak_iops & absolute_min_iops")
+		return out, errors.New("at least one updatable field must be provided: new_name, max_throughput_iops & min_throughput_iops, expected_iops & peak_iops & absolute_min_iops, or expected_iops_allocation/peak_iops_allocation/block_size")
 	}
 
 	return out, nil
@@ -384,7 +384,7 @@ func newUpdateQoSPolicy(in tool.QoSPolicy) (ontap.QoSPolicy, error) {
 		hasUpdate = true
 	}
 	if !hasUpdate {
-		return out, errors.New("at least one updatable field must be provided: new_name, max_throughput_iops & min_throughput_iops or expected_iops & peak_iops & absolute_min_iops")
+		return out, errors.New("at least one updatable field must be provided: new_name, max_throughput_iops & min_throughput_iops, expected_iops & peak_iops & absolute_min_iops, or expected_iops_allocation/peak_iops_allocation/block_size")
 	}
 
 	return out, nil

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -151,16 +151,19 @@ type Cron struct {
 }
 
 type QoSPolicy struct {
-	Cluster         string `json:"cluster_name" jsonschema:"cluster name"`
-	SVM             string `json:"svm_name" jsonschema:"SVM name"`
-	Name            string `json:"name" jsonschema:"qos policy name"`
-	NewName         string `json:"new_name,omitzero" jsonschema:"new qos policy name"`
-	MaxThIOPS       string `json:"max_throughput_iops,omitzero" jsonschema:"max throughput of fixed qos policy"`
-	MinThIOPS       string `json:"min_throughput_iops,omitzero" jsonschema:"min throughput of fixed qos policy"`
-	ExpectedIOPS    string `json:"expected_iops,omitzero" jsonschema:"expected iops of adaptive qos policy"`
-	PeakIOPS        string `json:"peak_iops,omitzero" jsonschema:"peak iops of adaptive qos policy"`
-	AbsoluteMinIOPS string `json:"absolute_min_iops,omitzero" jsonschema:"absolute min iops of adaptive qos policy"`
-	CapacityShared  bool   `json:"capacity_shared,omitzero" jsonschema:"whether the capacities are shared across all objects that use this QoS policy-group. Default is false."`
+	Cluster                string `json:"cluster_name" jsonschema:"cluster name"`
+	SVM                    string `json:"svm_name" jsonschema:"SVM name"`
+	Name                   string `json:"name" jsonschema:"qos policy name"`
+	NewName                string `json:"new_name,omitzero" jsonschema:"new qos policy name"`
+	MaxThIOPS              string `json:"max_throughput_iops,omitzero" jsonschema:"max throughput of fixed qos policy"`
+	MinThIOPS              string `json:"min_throughput_iops,omitzero" jsonschema:"min throughput of fixed qos policy"`
+	ExpectedIOPS           string `json:"expected_iops,omitzero" jsonschema:"expected iops of adaptive qos policy"`
+	PeakIOPS               string `json:"peak_iops,omitzero" jsonschema:"peak iops of adaptive qos policy"`
+	AbsoluteMinIOPS        string `json:"absolute_min_iops,omitzero" jsonschema:"absolute min iops of adaptive qos policy"`
+	ExpectedIOPSAllocation string `json:"expected_iops_allocation,omitzero" jsonschema:"adaptive QoS expected IOPS allocation mode (e.g., 'allocated_space')"`
+	PeakIOPSAllocation     string `json:"peak_iops_allocation,omitzero" jsonschema:"adaptive QoS peak IOPS allocation mode (e.g., 'allocated_space')"`
+	BlockSize              string `json:"block_size,omitzero" jsonschema:"adaptive QoS block size (e.g., 'any')"`
+	CapacityShared         bool   `json:"capacity_shared,omitzero" jsonschema:"whether the capacities are shared across all objects that use this QoS policy-group. Default is false."`
 }
 
 type QoSPolicyModify struct {
@@ -172,12 +175,15 @@ type QoSPolicyModify struct {
 }
 
 type QoSPolicyUpdate struct {
-	NewName         string `json:"new_name,omitzero" jsonschema:"new QoS policy name"`
-	MaxThIOPS       string `json:"max_throughput_iops,omitzero" jsonschema:"max throughput of fixed QoS policy"`
-	MinThIOPS       string `json:"min_throughput_iops,omitzero" jsonschema:"min throughput of fixed QoS policy"`
-	ExpectedIOPS    string `json:"expected_iops,omitzero" jsonschema:"expected iops of adaptive QoS policy"`
-	PeakIOPS        string `json:"peak_iops,omitzero" jsonschema:"peak iops of adaptive QoS policy"`
-	AbsoluteMinIOPS string `json:"absolute_min_iops,omitzero" jsonschema:"absolute min iops of adaptive QoS policy"`
+	NewName                string `json:"new_name,omitzero" jsonschema:"new QoS policy name"`
+	MaxThIOPS              string `json:"max_throughput_iops,omitzero" jsonschema:"max throughput of fixed QoS policy"`
+	MinThIOPS              string `json:"min_throughput_iops,omitzero" jsonschema:"min throughput of fixed QoS policy"`
+	ExpectedIOPS           string `json:"expected_iops,omitzero" jsonschema:"expected iops of adaptive QoS policy"`
+	PeakIOPS               string `json:"peak_iops,omitzero" jsonschema:"peak iops of adaptive QoS policy"`
+	AbsoluteMinIOPS        string `json:"absolute_min_iops,omitzero" jsonschema:"absolute min iops of adaptive QoS policy"`
+	ExpectedIOPSAllocation string `json:"expected_iops_allocation,omitzero" jsonschema:"adaptive QoS expected IOPS allocation mode (e.g., 'allocated_space')"`
+	PeakIOPSAllocation     string `json:"peak_iops_allocation,omitzero" jsonschema:"adaptive QoS peak IOPS allocation mode (e.g., 'allocated_space')"`
+	BlockSize              string `json:"block_size,omitzero" jsonschema:"adaptive QoS block size (e.g., 'any')"`
 }
 
 type NFSExportPolicyCreate struct {


### PR DESCRIPTION
Closes #175

## What this PR does

Adds three missing fields to `create_qos_policy` and `update_qos_policy` for adaptive QoS policies:

| New field | ONTAP REST path | Example |
|---|---|---|
| `expected_iops_allocation` | `adaptive.expected_iops_allocation` | `"allocated_space"` |
| `peak_iops_allocation` | `adaptive.peak_iops_allocation` | `"allocated_space"` |
| `block_size` | `adaptive.block_size` | `"any"` |

Without these fields it is impossible to create an adaptive QoS policy with a specific allocation mode or block size. All three are omitted from the REST body when empty, preserving the existing default behavior.

## Supporting change: `rest.Client.handleJob` refactor

Includes the same `handleJob` refactor as PR #178. Only needs to be merged once across the four companion PRs.

## Files changed

| File | Change |
|---|---|
| `tool/tool.go` | Add `ExpectedIOPSAllocation`, `PeakIOPSAllocation`, `BlockSize` to `QoSPolicy` |
| `ontap/ontap.go` | Add same three fields to `QoSAdaptive` |
| `server/QoSPolicy.go` | Propagate in `newCreateQoSPolicy` and `newUpdateQoSPolicy` |
| `server/qospolicy_typed_fields_test.go` | New: adaptive allocation field propagation test |
| `rest/client.go` + `rest/*.go` + `rest/job_wait_test.go` | `handleJob` refactor (same as #178) |

Raised by **NetApp CPOC**.

Made with [Cursor](https://cursor.com)