### PR TITLE
feat: add optional HTTP listener to ListenerSet for ACME HTTP-01

### DIFF
--- a/charts/ontap-mcp/templates/listenerset.yaml
+++ b/charts/ontap-mcp/templates/listenerset.yaml
@@ -12,6 +12,12 @@ metadata:
   {{- end }}
 spec:
   listeners:
+    {{- if .Values.listenerSet.http.enabled }}
+    - name: http
+      hostname: {{ .Values.listenerSet.hostname }}
+      port: {{ .Values.listenerSet.http.port }}
+      protocol: HTTP
+    {{- end }}
     - name: https
       hostname: {{ .Values.listenerSet.hostname }}
       port: 443

--- a/charts/ontap-mcp/values.yaml
+++ b/charts/ontap-mcp/values.yaml
@@ -165,3 +165,9 @@ listenerSet:
     name: my-gateway
   hostname: chart-example.local
   tlsSecretName: ""
+  # -- Plain-HTTP listener on this ListenerSet, e.g. for ACME HTTP-01 challenge
+  # solving via the Gateway API. Not needed for DNS-01 or if challenges are
+  # solved elsewhere, so it's off by default like the rest of this block.
+  http:
+    enabled: false
+    port: 80


### PR DESCRIPTION
Closes #186.

`listenerSet` only defined an HTTPS/443 listener. If cert-manager solves ACME via HTTP-01 through the Gateway API, it needs an HTTP listener on this ListenerSet's hostname to route the challenge -- the shared Gateway's own listener doesn't match, since the challenge route needs `listenerSet.hostname` specifically.

Gated behind `listenerSet.http.enabled` (off by default), same pattern as the existing `ingress`/`httpRoute` toggles -- DNS-01 users don't need this and shouldn't get an unconditional open port 80.

Verified with `helm lint` and `helm template` for both `http.enabled=false` (unchanged output) and `true` (listener added, port configurable).