### PR TITLE
feat: add optional ExternalSecret support to Helm chart

### DIFF
--- a/charts/ontap-mcp/templates/NOTES.txt
+++ b/charts/ontap-mcp/templates/NOTES.txt
@@ -1,6 +1,6 @@
 ONTAP MCP Server has been deployed.
 
-{{- if and (not .Values.ontapConfig.existingSecret) (not .Values.ontapConfig.data) }}
+{{- if and (not .Values.ontapConfig.existingSecret) (not .Values.ontapConfig.data) (not .Values.externalSecret.enabled) }}
 
 WARNING: no ONTAP clusters are configured (ontapConfig.data is empty and
 ontapConfig.existingSecret is not set). The server will start but has

--- a/charts/ontap-mcp/templates/_helpers.tpl
+++ b/charts/ontap-mcp/templates/_helpers.tpl
@@ -62,9 +62,16 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the Secret that carries ontap.yaml -- either the caller-supplied
-existingSecret, or the one this chart creates itself.
+Name of the Secret that carries ontap.yaml -- the caller-supplied
+existingSecret, the name ESO's ExternalSecret creates, or the one this
+chart creates itself, in that order of precedence.
 */}}
 {{- define "ontap-mcp.configSecretName" -}}
-{{- default (printf "%s-config" (include "ontap-mcp.fullname" .)) .Values.ontapConfig.existingSecret }}
+{{- if .Values.ontapConfig.existingSecret }}
+{{- .Values.ontapConfig.existingSecret }}
+{{- else if .Values.externalSecret.enabled }}
+{{- default (printf "%s-config" (include "ontap-mcp.fullname" .)) .Values.externalSecret.target.name }}
+{{- else }}
+{{- printf "%s-config" (include "ontap-mcp.fullname" .) }}
+{{- end }}
 {{- end }}

--- a/charts/ontap-mcp/templates/deployment.yaml
+++ b/charts/ontap-mcp/templates/deployment.yaml
@@ -11,9 +11,9 @@ spec:
       {{- include "ontap-mcp.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- if or (not .Values.ontapConfig.existingSecret) .Values.podAnnotations }}
+      {{- if or (and (not .Values.ontapConfig.existingSecret) (not .Values.externalSecret.enabled)) .Values.podAnnotations }}
       annotations:
-        {{- if not .Values.ontapConfig.existingSecret }}
+        {{- if and (not .Values.ontapConfig.existingSecret) (not .Values.externalSecret.enabled) }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}

--- a/charts/ontap-mcp/templates/externalsecret.yaml
+++ b/charts/ontap-mcp/templates/externalsecret.yaml
@@ -1,4 +1,10 @@
 {{- if and .Values.externalSecret.enabled (not .Values.ontapConfig.existingSecret) }}
+{{- if not .Values.externalSecret.secretStoreRef.name }}
+{{- fail "externalSecret.secretStoreRef.name is required when externalSecret.enabled is true" }}
+{{- end }}
+{{- if not (or .Values.externalSecret.data .Values.externalSecret.dataFrom) }}
+{{- fail "externalSecret.data or externalSecret.dataFrom is required when externalSecret.enabled is true" }}
+{{- end }}
 apiVersion: {{ .Values.externalSecret.apiVersion }}
 kind: ExternalSecret
 metadata:

--- a/charts/ontap-mcp/templates/externalsecret.yaml
+++ b/charts/ontap-mcp/templates/externalsecret.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.externalSecret.enabled (not .Values.ontapConfig.existingSecret) }}
+apiVersion: {{ .Values.externalSecret.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "ontap-mcp.configSecretName" . }}
+  labels:
+    {{- include "ontap-mcp.labels" . | nindent 4 }}
+    {{- with .Values.externalSecret.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.externalSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecret.secretStoreRef | nindent 4 }}
+  target:
+    name: {{ include "ontap-mcp.configSecretName" . }}
+    creationPolicy: Owner
+    {{- with .Values.externalSecret.template }}
+    template:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- with .Values.externalSecret.data }}
+  data:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.externalSecret.dataFrom }}
+  dataFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ontap-mcp/templates/secret.yaml
+++ b/charts/ontap-mcp/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.ontapConfig.existingSecret }}
+{{- if and (not .Values.ontapConfig.existingSecret) (not .Values.externalSecret.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/ontap-mcp/values.yaml
+++ b/charts/ontap-mcp/values.yaml
@@ -92,6 +92,49 @@ ontapConfig:
   #       use_insecure_tls: false
   data: {}
 
+# -- Source the ontap.yaml config Secret from an External Secrets Operator
+# (https://external-secrets.io) ExternalSecret instead of setting it inline
+# via `ontapConfig.data` or pointing at a Secret you manage yourself via
+# `ontapConfig.existingSecret`. Off by default; when enabled, the chart
+# creates the ExternalSecret and skips creating a plain Secret of its own --
+# `ontapConfig.data` is ignored, same as with `ontapConfig.existingSecret`.
+externalSecret:
+  enabled: false
+  # -- API version of the ExternalSecret CRD. Most current ESO installs are
+  # on `external-secrets.io/v1`; some clusters are still on the deprecated
+  # `external-secrets.io/v1beta1`.
+  apiVersion: external-secrets.io/v1
+  # -- How often ESO re-syncs the Secret from the external store.
+  refreshInterval: 1h
+  # -- The (Cluster)SecretStore holding the ONTAP credentials. `name` is
+  # required when `enabled` is true.
+  secretStoreRef:
+    name: ""
+    kind: ClusterSecretStore
+  # -- Name of the Kubernetes Secret ESO creates. Defaults to the same name
+  # the chart's own Secret would otherwise use.
+  target:
+    name: ""
+  annotations: {}
+  labels: {}
+  # -- Individual keys to fetch, in ESO's own `spec.data` form. The default
+  # here expects a single remote key holding the complete ontap.yaml content
+  # already, mapped to the `ontap.yaml` key the server reads. Example:
+  #
+  # data:
+  #   - secretKey: ontap.yaml
+  #     remoteRef:
+  #       key: secret/ontap-mcp-config
+  data: []
+  # -- Alternative to `data`: pull every key/value from one remote secret in
+  # bulk, in ESO's own `spec.dataFrom` form. Mutually exclusive with `data`
+  # in ESO's schema -- leave `data` empty (`[]`) if you use this.
+  dataFrom: []
+  # -- Optional ESO `spec.target.template` block, e.g. to compose ontap.yaml
+  # from several remote keys. See
+  # https://external-secrets.io/latest/guides/templating/
+  template: {}
+
 resources:
   limits:
     cpu: 1

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -36,7 +36,7 @@ The server needs a config file, `ontap.yaml`, describing which ONTAP clusters
 to connect to. The chart always sources that file from a Kubernetes `Secret`
 mounted at `/opt/mcp/ontap.yaml`.
 
-You can provide it in one of two ways:
+You can provide it in one of three ways:
 
 1. Let the chart create the `Secret` by setting `ontapConfig.data` to the full
    contents of `ontap.yaml`, in its native schema:
@@ -64,7 +64,66 @@ You can provide it in one of two ways:
    `ontapConfig.existingSecret` to its name. When this is set,
    `ontapConfig.data` is ignored.
 
-If neither option is set, the server still starts with no configured clusters.
+3. Let the chart create and manage an
+   [`ExternalSecret`](https://external-secrets.io) for you, by setting
+   `externalSecret.enabled` to `true`:
+
+   ```yaml
+   externalSecret:
+     enabled: true
+     secretStoreRef:
+       name: my-secret-store
+       kind: ClusterSecretStore
+     data:
+       - secretKey: ontap.yaml
+         remoteRef:
+           key: secret/ontap-mcp-config
+   ```
+
+   `secretStoreRef`, `refreshInterval`, `data`/`dataFrom`, and `template` map
+   directly onto the External Secrets Operator's own `ExternalSecret` spec --
+   see its [templating guide](https://external-secrets.io/latest/guides/templating/)
+   for composing `ontap.yaml` from more than one remote key. When this is
+   set, the chart does not render its own `Secret` and `ontapConfig.data` is
+   ignored, same as with `ontapConfig.existingSecret`.
+
+   If the credentials live as separate keys in the secret backend rather
+   than one ready-made `ontap.yaml` blob, use `template` to compose them:
+
+   ```yaml
+   externalSecret:
+     enabled: true
+     secretStoreRef:
+       name: my-secret-store
+       kind: ClusterSecretStore
+     data:
+       - secretKey: cluster1_addr
+         remoteRef:
+           key: ontap-cluster1-addr
+       - secretKey: cluster1_user
+         remoteRef:
+           key: ontap-cluster1-user
+       - secretKey: cluster1_password
+         remoteRef:
+           key: ontap-cluster1-password
+     template:
+       engineVersion: v2
+       data:
+         ontap.yaml: |
+           Pollers:
+             cluster1:
+               addr: {{ .cluster1_addr }}
+               username: {{ .cluster1_user }}
+               password: {{ .cluster1_password }}
+               use_insecure_tls: false
+   ```
+
+   Most current ESO installs are on the `external-secrets.io/v1` API, which
+   is the default. Set `externalSecret.apiVersion` to
+   `external-secrets.io/v1beta1` if your cluster's ESO hasn't been upgraded
+   yet.
+
+If none of these are set, the server still starts with no configured clusters.
 
 ## Exposing the service
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -7,6 +7,10 @@ ONTAP-MCP includes an official Helm chart in this repository at `charts/ontap-mc
 - Kubernetes 1.27+
 - Helm 3.12+
 - Network connectivity from the ONTAP-MCP pod to your ONTAP clusters
+- If using `externalSecret.enabled` (see [Configuration](#configuration)):
+  the [External Secrets Operator](https://external-secrets.io) CRDs and a
+  `SecretStore`/`ClusterSecretStore` already installed in the cluster. The
+  chart only renders the `ExternalSecret`, not the operator or the store.
 
 ## Installing
 
@@ -122,6 +126,13 @@ You can provide it in one of three ways:
    is the default. Set `externalSecret.apiVersion` to
    `external-secrets.io/v1beta1` if your cluster's ESO hasn't been upgraded
    yet.
+
+   The chart mounts `ontap.yaml` via `subPath`, so kubelet does not
+   propagate an in-place Secret update into the running container. When ESO
+   refreshes the Secret on `refreshInterval`, roll the deployment yourself
+   to pick up the change, e.g. `kubectl rollout restart deployment`. This
+   also applies to `ontapConfig.existingSecret`; only `ontapConfig.data`
+   triggers an automatic rollout, via a checksum pod annotation.
 
 If none of these are set, the server still starts with no configured clusters.
 


### PR DESCRIPTION
## Summary

Adds `externalSecret.enabled` (off by default) as a third config path for the `ontap.yaml` config Secret, alongside `ontapConfig.data` and `ontapConfig.existingSecret`. Today ESO-backed clusters need a hand-maintained `ExternalSecret` manifest kept in sync with the chart release on every upgrade; when enabled, the chart renders it itself instead.

- Precedence: `existingSecret` > `externalSecret` > chart-managed `Secret`, consistent with the existing `existingSecret` behavior.
- `secretStoreRef`, `refreshInterval`, `data`/`dataFrom`, and `target.template` map directly onto ESO's own `ExternalSecret` spec — a thin pass-through, not a new abstraction.
- `apiVersion` defaults to `external-secrets.io/v1`, overridable to `v1beta1` for clusters not yet migrated.
- `docs/helm.md` updated with a single-blob example and a multi-field `template`-composition example.

Closes #200

## Context

Reviewed internally with our PKS/AKS platform team (Stefan) before opening this, per the discussion in #200.

## Test plan

- `helm lint charts/ontap-mcp`
- `helm template` verified for all three config paths (default, `existingSecret`, `externalSecret`), including the precedence case where both `existingSecret` and `externalSecret.enabled` are set (the latter correctly yields to `existingSecret`, no `ExternalSecret` rendered).

cc @cgrinds